### PR TITLE
feat: add automatic release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
+      - name: Install release script dependencies
+        run: npm ci --ignore-scripts
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: gooeypi-public-*

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -4,7 +4,7 @@ import { extname, join, resolve } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { pathToFileURL } from 'node:url'
-import { BROWSER_PARTITION, type AppMeta, type HarnessId, type PrimeEventEnvelope, type ProviderAuthEvent } from '../../src/types/api'
+import { BROWSER_PARTITION, type AppMeta, type AppUpdateState, type HarnessId, type PrimeEventEnvelope, type ProviderAuthEvent } from '../../src/types/api'
 import { AgentRpcManager, OMP_RPC_ADAPTER, PI_RPC_ADAPTER } from './agent-rpc'
 import { BrowserDownloadGuard } from './browser-downloads'
 import { installCrashGuards } from './crash-guard'
@@ -35,6 +35,7 @@ import { JsonStateStore } from './store'
 import { TerminalService } from './terminal'
 import { VoiceService, voiceSecretStorageStatus } from './voice'
 import { isAllowedRendererAudioPermission } from './voice-permissions'
+import { getAutoUpdater, UpdateService } from './updates'
 
 protocol.registerSchemesAsPrivileged([{ scheme: 'prime-work', privileges: { standard: true, secure: true, supportFetchAPI: true } }])
 
@@ -46,6 +47,7 @@ let piAgents: AgentRpcManager | null = null
 let terminals: TerminalService | null = null
 let downloads: BrowserDownloadGuard | null = null
 let providerService: PrimeProviderService | null = null
+let updateService: UpdateService | null = null
 let store: JsonStateStore | null = null
 let automation: AutomationService | null = null
 let agentScheduleBridges: AgentScheduleBridge[] = []
@@ -779,6 +781,8 @@ async function bootstrap(): Promise<void> {
     homeDir: homedir(),
     harnesses: initialHarnesses,
   }
+  const updates = new UpdateService(getAutoUpdater(), { enabled: app.isPackaged })
+  updateService = updates
   const refreshHarnesses = async () => {
     const harnesses = await discovery.refresh()
     const currentSettings = await reconcileActiveHarness(stateStore, harnesses)
@@ -787,7 +791,7 @@ async function bootstrap(): Promise<void> {
   }
   trustedRendererUrl = resolveRendererUrl()
   ipc = registerIpc({
-    meta, refreshHarnesses, projects, sessions, agents, terminals, git, plugins, providers, settings, cuaDriver, heartbeats, schedules, browser: browserService, voice, pets,
+    meta, refreshHarnesses, projects, sessions, agents, terminals, git, plugins, providers, settings, updates, cuaDriver, heartbeats, schedules, browser: browserService, voice, pets,
     omp: { projects: ompProjects, sessions: ompSessions, agents: ompManager, catalog: ompCatalog, plugins: ompPlugins },
     pi: { projects: piProjects, sessions: piSessions, agents: piManager, catalog: piCatalog, plugins: piPlugins },
   }, trustedRendererUrl)
@@ -812,7 +816,16 @@ async function bootstrap(): Promise<void> {
       renderer.send('providers:auth-event', event)
     }
   })
+  updates.setEventSink((state: AppUpdateState) => {
+    const renderer = mainWindow?.webContents
+    if (!shutdownStarted && renderer && !renderer.isDestroyed()
+      && isTrustedRendererUrl(renderer.getURL(), trustedRendererUrl)
+      && isTrustedRendererUrl(renderer.mainFrame.url, trustedRendererUrl)) {
+      renderer.send('updates:changed', state)
+    }
+  })
   await ensureWindow()
+  updates.start()
 }
 
 const hasSingleInstanceLock = app.requestSingleInstanceLock()
@@ -864,6 +877,7 @@ app.on('before-quit', (event) => {
   const registration = ipc
   ipc = null
   registration?.dispose()
+  updateService?.dispose()
   agents?.beginShutdown()
   ompAgents?.beginShutdown()
   piAgents?.beginShutdown()

--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -14,6 +14,7 @@ import type { HeartbeatService } from './schedules/heartbeats'
 import type { SessionService } from './sessions'
 import type { TerminalService } from './terminal'
 import type { VoiceService } from './voice'
+import type { UpdateService } from './updates'
 import type { AgentBrowserService } from './browser/agent-service'
 import { requireExistingPath, requireRecord, requireString, requireWebUrl } from './validation'
 
@@ -28,6 +29,7 @@ interface Services {
   plugins: PluginService
   providers: PrimeProviderService
   settings: SettingsService
+  updates: UpdateService
   cuaDriver: CuaDriverService
   heartbeats: HeartbeatService
   schedules: AutomationService
@@ -183,6 +185,9 @@ export function registerIpc(services: Services, expectedRendererUrl: string): Ip
     }
     return false
   })
+  handle('updates:get-state', () => services.updates.getState())
+  handle('updates:check', () => services.updates.check())
+  handle('updates:install', () => services.updates.install())
 
   handle('projects:list', (_event, harness) => projectsFor(requireHarness(harness)).list())
   handle('projects:list-files', (_event, root, harness) => projectsFor(requireHarness(harness)).listFiles(root))

--- a/electron/main/updates.ts
+++ b/electron/main/updates.ts
@@ -1,0 +1,119 @@
+import electronUpdater, { type AppUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater'
+import type { AppUpdateState } from '../../src/types/api'
+
+const DEFAULT_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+const INITIAL_CHECK_DELAY_MS = 8_000
+
+export interface UpdateAdapter {
+  autoDownload: boolean
+  autoInstallOnAppQuit: boolean
+  on(event: 'checking-for-update', listener: () => void): this
+  on(event: 'update-available' | 'update-not-available' | 'update-downloaded', listener: (info: UpdateInfo) => void): this
+  on(event: 'download-progress', listener: (progress: ProgressInfo) => void): this
+  on(event: 'error', listener: (error: Error) => void): this
+  checkForUpdates(): Promise<unknown>
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
+}
+
+export interface UpdateServiceOptions {
+  enabled: boolean
+  checkIntervalMs?: number
+  initialCheckDelayMs?: number
+  setInterval?: typeof globalThis.setInterval
+  clearInterval?: typeof globalThis.clearInterval
+  setTimeout?: typeof globalThis.setTimeout
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.replace(/[\r\n\t]+/g, ' ').slice(0, 240) || 'Update check failed'
+}
+
+export function getAutoUpdater(): AppUpdater {
+  // electron-updater is CommonJS; accessing through its default export keeps
+  // the bundled Electron ESM output compatible with both Node module modes.
+  return electronUpdater.autoUpdater
+}
+
+export class UpdateService {
+  private state: AppUpdateState
+  private sink: ((state: AppUpdateState) => void) | null = null
+  private checkPromise: Promise<AppUpdateState> | null = null
+  private interval: ReturnType<typeof globalThis.setInterval> | null = null
+  private initialTimer: ReturnType<typeof globalThis.setTimeout> | null = null
+  private readonly setIntervalFn: typeof globalThis.setInterval
+  private readonly clearIntervalFn: typeof globalThis.clearInterval
+  private readonly setTimeoutFn: typeof globalThis.setTimeout
+
+  constructor(private readonly updater: UpdateAdapter, private readonly options: UpdateServiceOptions) {
+    this.state = options.enabled ? { phase: 'idle' } : { phase: 'unsupported', message: 'Automatic updates are available in installed builds.' }
+    this.setIntervalFn = options.setInterval ?? globalThis.setInterval
+    this.clearIntervalFn = options.clearInterval ?? globalThis.clearInterval
+    this.setTimeoutFn = options.setTimeout ?? globalThis.setTimeout
+    if (!options.enabled) return
+
+    updater.autoDownload = true
+    updater.autoInstallOnAppQuit = true
+    updater.on('checking-for-update', () => this.publish({ phase: 'checking' }))
+    updater.on('update-available', (info) => this.publish({ phase: 'available', version: info.version }))
+    updater.on('download-progress', (progress) => this.publish({
+      phase: 'downloading',
+      version: this.state.version,
+      percent: Math.max(0, Math.min(100, Math.round(progress.percent))),
+    }))
+    updater.on('update-downloaded', (info) => this.publish({ phase: 'downloaded', version: info.version }))
+    updater.on('update-not-available', (info) => this.publish({ phase: 'not-available', version: info.version }))
+    updater.on('error', (error) => this.publish({ phase: 'error', message: errorMessage(error) }))
+  }
+
+  start(): void {
+    if (!this.options.enabled || this.interval || this.initialTimer) return
+    this.initialTimer = this.setTimeoutFn(() => {
+      this.initialTimer = null
+      void this.check()
+    }, this.options.initialCheckDelayMs ?? INITIAL_CHECK_DELAY_MS)
+    this.initialTimer.unref?.()
+    this.interval = this.setIntervalFn(() => { void this.check() }, this.options.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS)
+    this.interval.unref?.()
+  }
+
+  dispose(): void {
+    if (this.interval) this.clearIntervalFn(this.interval)
+    if (this.initialTimer) clearTimeout(this.initialTimer)
+    this.interval = null
+    this.initialTimer = null
+    this.sink = null
+  }
+
+  getState(): AppUpdateState {
+    return structuredClone(this.state)
+  }
+
+  setEventSink(sink: ((state: AppUpdateState) => void) | null): void {
+    this.sink = sink
+  }
+
+  check(): Promise<AppUpdateState> {
+    if (!this.options.enabled) return Promise.resolve(this.getState())
+    if (this.checkPromise) return this.checkPromise
+    this.checkPromise = this.updater.checkForUpdates()
+      .then(() => this.getState())
+      .catch((error) => {
+        this.publish({ phase: 'error', message: errorMessage(error) })
+        return this.getState()
+      })
+      .finally(() => { this.checkPromise = null })
+    return this.checkPromise
+  }
+
+  install(): boolean {
+    if (!this.options.enabled || this.state.phase !== 'downloaded') return false
+    this.updater.quitAndInstall(false, true)
+    return true
+  }
+
+  private publish(state: AppUpdateState): void {
+    this.state = state
+    this.sink?.(this.getState())
+  }
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import type { AgentBrowserActivityEvent, AgentBrowserPointerEvent, AgentBrowserState, PrimeEventEnvelope, PrimeWorkApi, ProviderAuthEvent, ScheduleChangeEvent, SessionChangeEvent, TerminalDataEvent, TerminalExitEvent } from '../../src/types/api'
+import type { AgentBrowserActivityEvent, AgentBrowserPointerEvent, AgentBrowserState, AppUpdateState, PrimeEventEnvelope, PrimeWorkApi, ProviderAuthEvent, ScheduleChangeEvent, SessionChangeEvent, TerminalDataEvent, TerminalExitEvent } from '../../src/types/api'
 
 function subscribe<T>(channel: string, callback: (payload: T) => void): () => void {
   if (typeof callback !== 'function') throw new TypeError('callback must be a function')
@@ -16,6 +16,12 @@ const api: PrimeWorkApi = {
     refreshHarnesses: () => ipcRenderer.invoke('app:refresh-harnesses'),
     openExternal: (url) => ipcRenderer.invoke('app:open-external', url),
     revealPath: (path) => ipcRenderer.invoke('app:reveal-path', path),
+  },
+  updates: {
+    getState: () => ipcRenderer.invoke('updates:get-state'),
+    check: () => ipcRenderer.invoke('updates:check'),
+    install: () => ipcRenderer.invoke('updates:install'),
+    onChanged: (callback) => subscribe<AppUpdateState>('updates:changed', callback),
   },
   projects: {
     list: (harness) => ipcRenderer.invoke('projects:list', harness),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "electron-updater": "^6.8.9",
         "node-pty": "^1.0.0",
         "prime-agent": "file:vendor/prime-agent-0.7.0-gooeypi.1.tgz",
         "prime-agent-ai": "file:vendor/prime-agent-ai-0.7.0-gooeypi.1.tgz",
@@ -31,6 +32,7 @@
         "electron": "^43.2.0",
         "electron-builder": "^26.15.7",
         "electron-vite": "^5.0.0",
+        "js-yaml": "^4.3.1",
         "jsdom": "^26.1.0",
         "lucide-react": "^0.468.0",
         "react": "^19.0.0",
@@ -3761,7 +3763,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -4052,7 +4053,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4927,6 +4927,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-vite": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-5.0.0.tgz",
@@ -5545,7 +5573,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6387,7 +6414,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6533,7 +6559,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -6588,7 +6613,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -6596,6 +6620,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -9147,7 +9184,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -9595,6 +9631,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9925,7 +9967,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "postinstall": "node scripts/release/install-app-deps.mjs"
   },
   "dependencies": {
+    "electron-updater": "^6.8.9",
     "node-pty": "^1.0.0",
     "prime-agent": "file:vendor/prime-agent-0.7.0-gooeypi.1.tgz",
     "prime-agent-ai": "file:vendor/prime-agent-ai-0.7.0-gooeypi.1.tgz",
@@ -65,6 +66,7 @@
     "electron": "^43.2.0",
     "electron-builder": "^26.15.7",
     "electron-vite": "^5.0.0",
+    "js-yaml": "^4.3.1",
     "jsdom": "^26.1.0",
     "lucide-react": "^0.468.0",
     "react": "^19.0.0",
@@ -160,6 +162,11 @@
     },
     "directories": {
       "output": "release"
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "am-will",
+      "repo": "gooey-pi"
     },
     "afterPack": "scripts/release/after-pack.cjs",
     "extraResources": [

--- a/scripts/release/prepare-github-release.mjs
+++ b/scripts/release/prepare-github-release.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
-import { copyFileSync, createReadStream, existsSync, lstatSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
+import { copyFileSync, createReadStream, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { basename, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { dump, load } from 'js-yaml'
 import { validateReleaseTag } from './validate-release-tag.mjs'
 
 const RELEASE_PLATFORMS = ['mac', 'linux', 'win']
+const UPDATE_METADATA = { mac: 'latest-mac.yml', linux: 'latest-linux.yml', win: 'latest.yml' }
 
 export function parseReleasePlatforms(value = RELEASE_PLATFORMS.join(',')) {
   const platforms = value
@@ -25,7 +27,44 @@ export function expectedGitHubReleaseAssets(version, platforms = RELEASE_PLATFOR
     linux: [`GooeyPi-${version}-linux-x86_64.AppImage`, `GooeyPi-${version}-linux-amd64.deb`, `GooeyPi-${version}-linux-x64.pacman`, `GooeyPi-${version}-linux-x86_64.rpm`],
     win: [`GooeyPi-${version}-win-x64.exe`, `GooeyPi-${version}-win-x64.zip`],
   }
-  return platforms.flatMap((platform) => assets[platform]).sort()
+  return platforms.flatMap((platform) => [...assets[platform], UPDATE_METADATA[platform]]).sort()
+}
+
+function parseUpdateMetadata(path, expectedVersion) {
+  const value = load(readFileSync(path, 'utf8'))
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`Update metadata is not an object: ${path}`)
+  if (value.version !== expectedVersion) throw new Error(`Update metadata version does not match ${expectedVersion}: ${path}`)
+  if (!Array.isArray(value.files) || !value.files.length) throw new Error(`Update metadata has no files: ${path}`)
+  for (const file of value.files) {
+    if (!file || typeof file !== 'object' || typeof file.url !== 'string' || !file.url || typeof file.sha512 !== 'string' || !file.sha512) {
+      throw new Error(`Update metadata contains an invalid file: ${path}`)
+    }
+  }
+  return value
+}
+
+export function mergeUpdateMetadata(paths, expectedVersion) {
+  if (!paths.length) throw new Error('Update metadata is missing')
+  const manifests = paths
+    .slice()
+    .sort()
+    .map((path) => parseUpdateMetadata(path, expectedVersion))
+  const files = new Map()
+  for (const manifest of manifests)
+    for (const file of manifest.files) {
+      const previous = files.get(file.url)
+      if (previous && (previous.sha512 !== file.sha512 || previous.size !== file.size)) throw new Error(`Update metadata disagrees for ${file.url}`)
+      files.set(file.url, file)
+    }
+  const mergedFiles = [...files.values()].sort((left, right) => left.url.localeCompare(right.url))
+  const preferredUrl = manifests.map((manifest) => manifest.path).find((path) => files.has(path))
+  const primary = files.get(preferredUrl) ?? mergedFiles[0]
+  return {
+    ...manifests[0],
+    files: mergedFiles,
+    path: primary.url,
+    sha512: primary.sha512,
+  }
 }
 
 export function expectedDownloadedReleaseAssets(version, platforms = RELEASE_PLATFORMS) {
@@ -60,19 +99,35 @@ export async function prepareGitHubRelease({ inputDirectory, outputDirectory, ta
   const downloaded = expectedDownloadedReleaseAssets(release.version, platforms)
   const expectedSet = new Set(downloaded)
   const selected = new Map()
+  const metadata = new Map()
   for (const path of listFiles(inputDirectory)) {
     const name = basename(path)
     if (!expectedSet.has(name)) continue
+    if (Object.values(UPDATE_METADATA).includes(name)) {
+      const candidates = metadata.get(name) ?? []
+      candidates.push(path)
+      metadata.set(name, candidates)
+      continue
+    }
     if (selected.has(name)) throw new Error(`Downloaded release artifacts contain duplicate files named ${name}`)
     selected.set(name, path)
   }
-  const missing = downloaded.filter((name) => !selected.has(name))
+  const missing = expected.filter((name, index) => !selected.has(downloaded[index]) && !metadata.has(name))
   if (missing.length) throw new Error(`Downloaded release artifacts are incomplete; missing ${missing.join(', ')}`)
 
   const checksumLines = []
   for (const [index, name] of expected.entries()) {
     const destination = join(outputDirectory, name)
-    copyFileSync(selected.get(downloaded[index]), destination)
+    const metadataPaths = metadata.get(name)
+    if (metadataPaths) {
+      const manifest = mergeUpdateMetadata(metadataPaths, release.version)
+      for (const file of manifest.files) {
+        if (file.url !== basename(file.url) || !expectedSet.has(file.url) || Object.values(UPDATE_METADATA).includes(file.url)) {
+          throw new Error(`Update metadata references an unpublished release asset: ${file.url}`)
+        }
+      }
+      writeFileSync(destination, dump(manifest, { lineWidth: -1, noRefs: true, sortKeys: false }))
+    } else copyFileSync(selected.get(downloaded[index]), destination)
     if (lstatSync(destination).size === 0) throw new Error(`Release asset is empty: ${name}`)
     checksumLines.push(`${await sha256(destination)}  ${name}`)
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { AgentBrowserLayer, type AgentSlotRect } from '@/components/AgentBrowser
 import { useAgentBrowserTabs } from '@/hooks/useAgentBrowserTabs'
 import { useAgentEvents } from '@/hooks/useAgentEvents'
 import { useAppSettings } from '@/hooks/useAppSettings'
+import { useAppUpdates } from '@/hooks/useAppUpdates'
 import { useBootstrap } from '@/hooks/useBootstrap'
 import { useBrowserAnnotations } from '@/hooks/useBrowserAnnotations'
 import { useExtensionUi } from '@/hooks/useExtensionUi'
@@ -101,6 +102,7 @@ export default function App() {
   const reportError = useCallback((error: unknown) => {
     setToast(errorMessage(error))
   }, [])
+  const appUpdates = useAppUpdates(bridge, reportError)
   useEffect(() => {
     window.localStorage.setItem('prime-work.cleared-session-attention', JSON.stringify(clearedAttention))
   }, [clearedAttention])
@@ -490,7 +492,7 @@ export default function App() {
       }} onOpenDocs={() => { if (bridge) void bridge.app.openExternal(HARNESS_PROVIDER_DOCS[activeHarness]) }} /> : null
 
   return <div className="app-shell" aria-busy={!initialized} data-platform={platform} data-ready={initialized ? 'true' : 'false'}>
-    {sidebarVisible && initialized ? <Sidebar projects={projects} sessions={sessions} clearedAttention={clearedAttention} activeProjectId={activeProject?.id} activeSessionId={workspace.activeSessionId} activeView={view} activeHarness={activeHarness} harnesses={meta?.harnesses ?? null} onSelectHarness={selectHarness} {...sidebarActions} overlay={layout.compactLayout} platform={platform} /> : null}
+    {sidebarVisible && initialized ? <Sidebar projects={projects} sessions={sessions} clearedAttention={clearedAttention} activeProjectId={activeProject?.id} activeSessionId={workspace.activeSessionId} activeView={view} activeHarness={activeHarness} harnesses={meta?.harnesses ?? null} updateState={appUpdates.state} onUpdateAction={appUpdates.act} onSelectHarness={selectHarness} {...sidebarActions} overlay={layout.compactLayout} platform={platform} /> : null}
     {sidebarVisible && initialized ? <button type="button" className="panel-scrim panel-scrim--sidebar" aria-label="Close sidebar" onClick={toggleSidebar} /> : null}
     <div className="workbench" inert={layout.compactLayout && sidebarVisible ? true : undefined}>
       <TitleToolbar project={view === 'session' ? activeProject : undefined} view={view} productName={HARNESS_PRODUCT_NAMES[activeHarness]} sidebarOpen={sidebarVisible} inspectorOpen={inspectorVisible} terminalOpen={terminalOpen} voiceOpen={voiceOrbOpen} onToggleSidebar={toggleSidebar} onToggleInspector={toggleInspector} onToggleTerminal={toggleTerminal} onToggleVoice={toggleVoice} onOpenBrowser={openBrowser} platform={platform} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
+  Download,
   Folder,
   FolderOpen,
   FolderPlus,
@@ -21,8 +22,8 @@ import {
   SquarePen,
   Trash2,
 } from 'lucide-react'
-import { memo, useEffect, useMemo, useState, type ReactElement } from 'react'
-import type { AppMeta, HarnessId, ProjectRecord, SessionRecord, WorkspaceView } from '@/types/api'
+import { memo, useEffect, useMemo, useState, type CSSProperties, type ReactElement } from 'react'
+import type { AppMeta, AppUpdateState, HarnessId, ProjectRecord, SessionRecord, WorkspaceView } from '@/types/api'
 import { formatRelative } from '@/lib/data'
 import { HARNESS_PRODUCT_NAMES, HARNESS_SELECTOR_ORDER, HARNESS_SHORT_NAMES } from '@/lib/harness'
 import { shortcutLabel } from '@/lib/platform-shortcuts'
@@ -38,6 +39,8 @@ export interface SidebarProps {
   activeHarness?: HarnessId
   harnesses?: AppMeta['harnesses'] | null
   clearedAttention?: Record<string, string>
+  updateState?: AppUpdateState
+  onUpdateAction?(): void | Promise<void>
   onSelectHarness?(harness: HarnessId): void
   onSelectProject(project: ProjectRecord): void
   onSelectSession(session: SessionRecord): void
@@ -113,6 +116,20 @@ function HarnessMark({ harness, size }: { harness: HarnessId; size: number }) {
   return <Mark size={size} />
 }
 
+function updateControlCopy(state: AppUpdateState): { label: string; title: string } {
+  const version = state.version ? ` ${state.version}` : ''
+  switch (state.phase) {
+    case 'checking': return { label: 'Checking for updates', title: 'Checking GitHub Releases for a new GooeyPi version' }
+    case 'available': return { label: `Update${version} found`, title: `GooeyPi${version} is downloading automatically` }
+    case 'downloading': return { label: `Downloading${version} · ${state.percent ?? 0}%`, title: `Downloading GooeyPi${version}` }
+    case 'downloaded': return { label: `Restart for${version}`, title: `Restart GooeyPi and install version${version}` }
+    case 'not-available': return { label: 'GooeyPi is up to date', title: 'Check again for a new GooeyPi release' }
+    case 'error': return { label: 'Update check failed', title: state.message ?? 'Try checking for updates again' }
+    case 'unsupported': return { label: 'Automatic updates', title: state.message ?? 'Automatic updates are available in installed builds' }
+    default: return { label: 'Release updates', title: 'Check for a new GooeyPi release' }
+  }
+}
+
 async function copySessionUuid(id: string): Promise<void> {
   if (navigator.clipboard?.writeText) {
     try {
@@ -133,7 +150,7 @@ async function copySessionUuid(id: string): Promise<void> {
   if (!copied) throw new Error('Copy is unavailable')
 }
 
-function SidebarView({ projects, sessions, activeProjectId, activeSessionId, activeView, activeHarness = 'omp', harnesses, clearedAttention = {}, onSelectHarness, onSelectProject, onSelectSession, onNavigate, onNewSession, onAddProject, onRemoveProject, onClose, onOpenPalette, onRenameSession, onArchiveSession, overlay = false, platform = 'darwin' }: SidebarProps) {
+function SidebarView({ projects, sessions, activeProjectId, activeSessionId, activeView, activeHarness = 'omp', harnesses, clearedAttention = {}, updateState = { phase: 'unsupported' }, onUpdateAction, onSelectHarness, onSelectProject, onSelectSession, onNavigate, onNewSession, onAddProject, onRemoveProject, onClose, onOpenPalette, onRenameSession, onArchiveSession, overlay = false, platform = 'darwin' }: SidebarProps) {
   const [query, setQuery] = useState('')
   const [harnessMenuOpen, setHarnessMenuOpen] = useState(false)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
@@ -155,6 +172,8 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
   const sidebarShortcut = shortcutLabel(platform, ['Primary', 'B'])
   const commandsShortcut = shortcutLabel(platform, ['Primary', 'K'])
   const settingsShortcut = shortcutLabel(platform, ['Primary', ','])
+  const updateCopy = updateControlCopy(updateState)
+  const updateBusy = updateState.phase === 'checking' || updateState.phase === 'available' || updateState.phase === 'downloading'
   useEffect(() => {
     if (!harnessMenuOpen) return
     const dismiss = (event: PointerEvent) => { if (!(event.target instanceof Element) || !event.target.closest('.brand-switcher')) setHarnessMenuOpen(false) }
@@ -305,6 +324,10 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
 
       <div className="sidebar__footer">
         <button type="button" title="Commands" onClick={onOpenPalette}><Search size={15} /><span>Commands</span><kbd>{commandsShortcut}</kbd></button>
+        <button type="button" className={`sidebar-update sidebar-update--${updateState.phase}`} title={updateCopy.title} aria-label={updateCopy.title} aria-live="polite" disabled={updateBusy} onClick={() => { void onUpdateAction?.() }}>
+          <span className="sidebar-update__icon" style={{ '--update-progress': `${updateState.percent ?? 0}%` } as CSSProperties}><Download size={12} /></span>
+          <span>{updateCopy.label}</span>
+        </button>
         <button type="button" title="Settings" className={activeView === 'settings' ? 'is-active' : ''} onClick={() => onNavigate('settings')}><Settings size={15} /><span>Settings</span><kbd>{settingsShortcut}</kbd></button>
       </div>
       {renameTarget ? <Modal title="Rename session" onClose={() => setRenameTarget(null)} footer={<><button type="button" className="button" onClick={() => setRenameTarget(null)}>Cancel</button><button type="button" className="button button--primary" disabled={!renameValue.trim()} onClick={() => { const target = renameTarget; const title = renameValue.trim(); setRenameTarget(null); void onRenameSession(target, title) }}>Rename</button></>}><label className="field"><span>Session name</span><input autoFocus value={renameValue} maxLength={200} onChange={(event) => setRenameValue(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && renameValue.trim()) { event.preventDefault(); const target = renameTarget; const title = renameValue.trim(); setRenameTarget(null); void onRenameSession(target, title) } }}/></label></Modal> : null}
@@ -322,6 +345,8 @@ export function areSidebarPropsEqual(previous: SidebarProps, next: SidebarProps)
     && previous.activeHarness === next.activeHarness
     && previous.harnesses === next.harnesses
     && previous.clearedAttention === next.clearedAttention
+    && previous.updateState === next.updateState
+    && previous.onUpdateAction === next.onUpdateAction
     && previous.onSelectHarness === next.onSelectHarness
     && previous.onSelectProject === next.onSelectProject
     && previous.onSelectSession === next.onSelectSession

--- a/src/hooks/useAppUpdates.ts
+++ b/src/hooks/useAppUpdates.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { AppUpdateState, PrimeWorkApi } from '@/types/api'
+
+const FALLBACK_STATE: AppUpdateState = { phase: 'unsupported', message: 'Automatic updates are available in installed builds.' }
+
+export function useAppUpdates(bridge: PrimeWorkApi | null, reportError: (error: unknown) => void) {
+  const [state, setState] = useState<AppUpdateState>(bridge ? { phase: 'idle' } : FALLBACK_STATE)
+
+  useEffect(() => {
+    if (!bridge) {
+      setState(FALLBACK_STATE)
+      return
+    }
+    let cancelled = false
+    const unsubscribe = bridge.updates.onChanged((next) => { if (!cancelled) setState(next) })
+    void bridge.updates.getState()
+      .then((next) => { if (!cancelled) setState(next) })
+      .catch((error) => { if (!cancelled) reportError(error) })
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [bridge, reportError])
+
+  const act = useCallback(async () => {
+    if (!bridge) return
+    try {
+      if (state.phase === 'downloaded') await bridge.updates.install()
+      else setState(await bridge.updates.check())
+    } catch (error) {
+      reportError(error)
+    }
+  }, [bridge, reportError, state.phase])
+
+  return { state, act }
+}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -23,7 +23,7 @@
 .sidebar__primary { padding: 5px 8px 7px; display: flex; flex-direction: column; gap: 1px; border-bottom: 1px solid var(--border); }
 .sidebar__primary > button, .sidebar__footer > button { width: 100%; height: 32px; display: flex; align-items: center; gap: 9px; padding: 0 8px; border-radius: 7px; color: var(--text-secondary); background: transparent; text-align: left; }
 .sidebar__primary > button:hover, .sidebar__footer > button:hover, .sidebar__primary > button.is-active, .sidebar__footer > button.is-active { color: var(--text); background: var(--surface-hover); }
-.sidebar__primary > button span:not(.nav-count), .sidebar__footer > button span { flex: 1; }
+.sidebar__primary > button span:not(.nav-count), .sidebar__footer > button span:not(.sidebar-update__icon) { flex: 1; }
 .sidebar__primary kbd, .sidebar__footer kbd { opacity: 0; transition: opacity 130ms ease-out; }
 .sidebar__primary button:hover kbd, .sidebar__footer button:hover kbd { opacity: 1; }
 .nav-count { min-width: 18px; height: 18px; display: grid; place-items: center; padding: 0 5px; border-radius: 9px; color: var(--prime); background: var(--prime-soft); font-size: 10.5px; font-weight: 650; }
@@ -78,3 +78,14 @@
 .session-status-mark--idle > span, .session-status-mark--unknown > span, .session-status-mark--failed > span { width: 7px; height: 7px; border-radius: 50%; background: var(--text-tertiary); }
 .session-row-wrap.has-attention .session-status-mark--failed > span { background: var(--danger); }
 .sidebar__footer { flex: 0 0 auto; padding: 7px 8px 9px; border-top: 1px solid var(--border); }
+.sidebar__footer > .sidebar-update { opacity: 1; }
+.sidebar-update__icon { position: relative; width: 22px; height: 22px; display: grid; place-items: center; flex: 0 0 22px; margin-left: -3px; border: 1px solid color-mix(in srgb, var(--prime) 24%, transparent); border-radius: 50%; color: var(--prime); background: var(--prime-soft); transition: transform 150ms ease-out, color 150ms ease-out, background 150ms ease-out; }
+.sidebar-update:hover .sidebar-update__icon { transform: translateY(-1px); background: color-mix(in srgb, var(--prime) 18%, var(--sidebar)); }
+.sidebar-update--checking .sidebar-update__icon, .sidebar-update--available .sidebar-update__icon { animation: update-pulse 1.4s ease-in-out infinite; }
+.sidebar-update--downloading .sidebar-update__icon { border-color: transparent; background: conic-gradient(var(--prime) var(--update-progress), var(--prime-soft) 0); }
+.sidebar-update--downloading .sidebar-update__icon::before { content: ''; position: absolute; inset: 2px; border-radius: inherit; background: var(--sidebar); }
+.sidebar-update--downloading .sidebar-update__icon > svg { position: relative; z-index: 1; }
+.sidebar-update--downloaded .sidebar-update__icon { color: white; background: var(--prime); box-shadow: 0 0 0 3px var(--prime-soft); }
+.sidebar-update--error .sidebar-update__icon { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 25%, transparent); background: var(--danger-soft); }
+.sidebar-update:disabled { cursor: default; }
+@keyframes update-pulse { 50% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--prime) 10%, transparent); } }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -33,6 +33,15 @@ export interface AppMeta {
   harnesses: Record<HarnessId, HarnessStatus>
 }
 
+export type AppUpdatePhase = 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'not-available' | 'error' | 'unsupported'
+
+export interface AppUpdateState {
+  phase: AppUpdatePhase
+  version?: string
+  percent?: number
+  message?: string
+}
+
 export interface ProjectRecord {
   id: string
   /** Agent harness this project grant belongs to; grants never cross harnesses. */
@@ -638,6 +647,12 @@ export interface AgentBrowserPointerEvent {
 
 export interface PrimeWorkApi {
   app: { getMeta(): Promise<AppMeta>; refreshHarnesses(): Promise<{ meta: AppMeta; settings: AppSettings }>; openExternal(url: string): Promise<boolean>; revealPath(path: string): Promise<boolean> }
+  updates: {
+    getState(): Promise<AppUpdateState>
+    check(): Promise<AppUpdateState>
+    install(): Promise<boolean>
+    onChanged(callback: (state: AppUpdateState) => void): () => void
+  }
   projects: {
     list(harness?: HarnessId): Promise<ProjectRecord[]>
     listFiles(root: string, harness?: HarnessId): Promise<ProjectFileListing>

--- a/tests/backend/preload-projects.test.ts
+++ b/tests/backend/preload-projects.test.ts
@@ -38,4 +38,16 @@ describe('preload project worktree bridge', () => {
       ['pets:sprite', 'gooey-pi'],
     ])
   })
+
+  it('exposes update status, check, and install calls', async () => {
+    const api = electronMocks.api as { updates: { getState(): Promise<unknown>; check(): Promise<unknown>; install(): Promise<unknown> } }
+    await api.updates.getState()
+    await api.updates.check()
+    await api.updates.install()
+    expect(electronMocks.ipcRenderer.invoke.mock.calls).toEqual([
+      ['updates:get-state'],
+      ['updates:check'],
+      ['updates:install'],
+    ])
+  })
 })

--- a/tests/backend/updates.test.ts
+++ b/tests/backend/updates.test.ts
@@ -1,0 +1,59 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { UpdateService, type UpdateAdapter } from '../../electron/main/updates'
+
+class FakeUpdater extends EventEmitter {
+  autoDownload = false
+  autoInstallOnAppQuit = false
+  checkForUpdates = vi.fn(async () => undefined)
+  quitAndInstall = vi.fn()
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('automatic update service', () => {
+  it('automatically checks installed builds and configures download-on-discovery', async () => {
+    vi.useFakeTimers()
+    const updater = new FakeUpdater()
+    const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: true, initialCheckDelayMs: 25, checkIntervalMs: 100 })
+    expect(updater.autoDownload).toBe(true)
+    expect(updater.autoInstallOnAppQuit).toBe(true)
+
+    service.start()
+    await vi.advanceTimersByTimeAsync(25)
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2)
+    service.dispose()
+  })
+
+  it('reports discovery, progress, completion, and installs only a downloaded update', () => {
+    const updater = new FakeUpdater()
+    const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: true })
+    const changed = vi.fn()
+    service.setEventSink(changed)
+
+    updater.emit('update-available', { version: '0.2.0' })
+    updater.emit('download-progress', { percent: 48.6 })
+    expect(service.getState()).toEqual({ phase: 'downloading', version: '0.2.0', percent: 49 })
+    expect(service.install()).toBe(false)
+
+    updater.emit('update-downloaded', { version: '0.2.0' })
+    expect(service.getState()).toEqual({ phase: 'downloaded', version: '0.2.0' })
+    expect(service.install()).toBe(true)
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    expect(changed).toHaveBeenCalled()
+  })
+
+  it('keeps development builds offline and explains why updates are unavailable', async () => {
+    const updater = new FakeUpdater()
+    const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: false })
+    service.start()
+    await expect(service.check()).resolves.toMatchObject({ phase: 'unsupported' })
+    expect(updater.checkForUpdates).not.toHaveBeenCalled()
+    expect(service.install()).toBe(false)
+  })
+})

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -596,8 +596,9 @@ test.describe('Prime Work desktop smoke', () => {
       return { type: typeof prime, groups: prime ? Object.keys(prime).sort() : [], voiceMethods: voice && typeof voice === 'object' ? Object.keys(voice).sort() : [] }
     })
     expect(bridge.type).toBe('object')
-    expect(bridge.groups).toEqual(['agent', 'app', 'browser', 'git', 'heartbeats', 'pets', 'plugins', 'projects', 'providers', 'schedules', 'sessions', 'settings', 'terminal', 'voice'])
+    expect(bridge.groups).toEqual(['agent', 'app', 'browser', 'git', 'heartbeats', 'pets', 'plugins', 'projects', 'providers', 'schedules', 'sessions', 'settings', 'terminal', 'updates', 'voice'])
     expect(bridge.voiceMethods).toContain('testSelfHosted')
+    await expect(page.evaluate(() => window.prime.updates.getState())).resolves.toMatchObject({ phase: 'unsupported' })
     const credentialStatus = await page.evaluate(() => window.prime.voice.credentialStatus())
     expect(typeof credentialStatus.storage.available).toBe('boolean')
     if (!credentialStatus.storage.available) expect(credentialStatus.storage.message).toMatch(/secure|credential|keyring|kwallet/i)
@@ -611,6 +612,25 @@ test.describe('Prime Work desktop smoke', () => {
     await expect(page.locator('.sidebar__brand small')).toHaveText('Work')
     await expect(page.locator('.sidebar__brand .prime-mark svg path')).toHaveCount(2)
     await expect(page.locator('.prime-mark img')).toHaveCount(0)
+    const updateControl = page.locator('.sidebar__footer .sidebar-update')
+    await expect(updateControl).toContainText('Automatic updates')
+    await expect(updateControl.locator('.lucide-download')).toBeVisible()
+    await expect(updateControl.evaluate((button) => button.nextElementSibling?.getAttribute('title'))).resolves.toBe('Settings')
+    const updateColor = await updateControl.locator('.sidebar-update__icon').evaluate((icon) => {
+      const reference = document.createElement('span')
+      reference.style.color = 'var(--prime)'
+      document.body.append(reference)
+      const colors = { actual: getComputedStyle(icon).color, theme: getComputedStyle(reference).color }
+      reference.remove()
+      return colors
+    })
+    expect(updateColor.actual).toBe(updateColor.theme)
+    const updateIconBounds = await updateControl.locator('.sidebar-update__icon').evaluate((icon) => {
+      const { width, height } = icon.getBoundingClientRect()
+      return { width, height }
+    })
+    expect(updateIconBounds.width).toBeCloseTo(22, 0)
+    expect(updateIconBounds.height).toBeCloseTo(22, 0)
   })
 
   test('left aligns the harness picker for Linux and Windows chrome', async () => {

--- a/tests/frontend/sidebar-archive.test.tsx
+++ b/tests/frontend/sidebar-archive.test.tsx
@@ -49,6 +49,28 @@ async function rightClick(element: Element) {
 }
 
 describe('sidebar project context menu', () => {
+  it('shows the automatic release control beside Settings and invokes its current action', async () => {
+    const onUpdateAction = vi.fn()
+    await act(async () => {
+      root.render(
+        <Sidebar
+          projects={[project]} sessions={[session]} activeView="session" updateState={{ phase: 'downloaded', version: '0.2.0' }} onUpdateAction={onUpdateAction}
+          onSelectProject={noop} onSelectSession={noop} onNavigate={noop} onNewSession={noop} onAddProject={noop} onRemoveProject={noop}
+          onClose={noop} onOpenPalette={noop} onRenameSession={async () => undefined} onArchiveSession={async () => undefined}
+        />,
+      )
+    })
+
+    const update = container.querySelector('.sidebar__footer .sidebar-update')
+    const settings = container.querySelector('.sidebar__footer button[title="Settings"]')
+    expect(update).not.toBeNull()
+    expect(update?.nextElementSibling).toBe(settings)
+    expect(update?.textContent).toContain('Restart for 0.2.0')
+    expect(update?.querySelector('.lucide-download')).not.toBeNull()
+    await press(update!)
+    expect(onUpdateAction).toHaveBeenCalledOnce()
+  })
+
   it('copies the exact session UUID from the session context menu', async () => {
     const writeText = vi.fn(async () => undefined)
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })

--- a/tests/release-scripts.test.ts
+++ b/tests/release-scripts.test.ts
@@ -295,6 +295,7 @@ describe('release preflight', () => {
     expect(workflow).toContain('node scripts/release/validate-release-tag.mjs --tag "$RELEASE_TAG"')
     expect(workflow).toContain('git merge-base --is-ancestor HEAD refs/remotes/origin/main')
     expect(workflow).toContain('node scripts/release/prepare-github-release.mjs')
+    expect(workflow).toMatch(/release-packages:[\s\S]*?npm ci --ignore-scripts[\s\S]*?node scripts\/release\/prepare-github-release\.mjs/)
     expect(workflow).toContain('actions/download-artifact@')
     expect(workflow).toContain('actions/attest-build-provenance@')
     expect(workflow).toContain('gh release create "$RELEASE_TAG" release-assets/*')
@@ -332,13 +333,14 @@ describe('GitHub Release publication', () => {
   test('selects an exact enabled platform set', () => {
     expect(parseReleasePlatforms('mac,linux')).toEqual(['mac', 'linux'])
     expect(expectedGitHubReleaseAssets('0.2.0', ['mac', 'linux'])).not.toContain('GooeyPi-0.2.0-win-x64.exe')
-    expect(expectedGitHubReleaseAssets('0.2.0', ['mac'])).toEqual(['GooeyPi-0.2.0-arm64.zip', 'GooeyPi-0.2.0-intel-chip.dmg', 'GooeyPi-0.2.0-m-chip.dmg', 'GooeyPi-0.2.0-x64.zip'])
-    expect(expectedDownloadedReleaseAssets('0.2.0', ['mac'])).toEqual(['GooeyPi-0.2.0-arm64.zip', 'GooeyPi-0.2.0-x64.dmg', 'GooeyPi-0.2.0-arm64.dmg', 'GooeyPi-0.2.0-x64.zip'])
+    expect(expectedGitHubReleaseAssets('0.2.0', ['mac'])).toEqual(['GooeyPi-0.2.0-arm64.zip', 'GooeyPi-0.2.0-intel-chip.dmg', 'GooeyPi-0.2.0-m-chip.dmg', 'GooeyPi-0.2.0-x64.zip', 'latest-mac.yml'])
+    expect(expectedDownloadedReleaseAssets('0.2.0', ['mac'])).toEqual(['GooeyPi-0.2.0-arm64.zip', 'GooeyPi-0.2.0-x64.dmg', 'GooeyPi-0.2.0-arm64.dmg', 'GooeyPi-0.2.0-x64.zip', 'latest-mac.yml'])
     expect(expectedGitHubReleaseAssets('0.2.0', ['linux'])).toEqual([
       'GooeyPi-0.2.0-linux-amd64.deb',
       'GooeyPi-0.2.0-linux-x64.pacman',
       'GooeyPi-0.2.0-linux-x86_64.AppImage',
       'GooeyPi-0.2.0-linux-x86_64.rpm',
+      'latest-linux.yml',
     ])
     expect(() => parseReleasePlatforms('mac,mac')).toThrow(/duplicates/)
     expect(() => parseReleasePlatforms('mac,android')).toThrow(/Unsupported/)
@@ -367,9 +369,15 @@ describe('GitHub Release publication', () => {
     for (const [index, name] of downloaded.entries()) {
       const artifactDirectory = join(inputDirectory, `artifact-${index}`)
       mkdirSync(artifactDirectory)
-      writeFileSync(join(artifactDirectory, name), `asset ${index}`)
-      writeFileSync(join(artifactDirectory, 'latest.yml'), 'ignored update metadata')
+      const updateTarget = name === 'latest-mac.yml' ? 'GooeyPi-0.2.0-arm64.zip' : name === 'latest-linux.yml' ? 'GooeyPi-0.2.0-linux-x86_64.AppImage' : 'GooeyPi-0.2.0-win-x64.exe'
+      const content = name.startsWith('latest')
+        ? `version: 0.2.0\nfiles:\n  - url: ${updateTarget}\n    sha512: checksum-${index}\n    size: ${index + 1}\npath: ${updateTarget}\nsha512: checksum-${index}\n`
+        : `asset ${index}`
+      writeFileSync(join(artifactDirectory, name), content)
     }
+    const secondMacManifest = join(inputDirectory, 'macos-x64')
+    mkdirSync(secondMacManifest)
+    writeFileSync(join(secondMacManifest, 'latest-mac.yml'), 'version: 0.2.0\nfiles:\n  - url: GooeyPi-0.2.0-x64.zip\n    sha512: checksum-x64\n    size: 42\n')
 
     try {
       const result = await prepareGitHubRelease({ inputDirectory, outputDirectory, projectDirectory, tag: 'v0.2.0' })
@@ -377,10 +385,15 @@ describe('GitHub Release publication', () => {
       expect(readdirSync(outputDirectory).sort()).toEqual([...expected, 'SHA256SUMS.txt'].sort())
       const checksums = readFileSync(join(outputDirectory, 'SHA256SUMS.txt'), 'utf8').trim().split('\n')
       expect(checksums).toHaveLength(expected.length)
-      for (const [index, name] of expected.entries()) {
-        const digest = createHash('sha256').update(`asset ${index}`).digest('hex')
+      for (const name of expected) {
+        const digest = createHash('sha256')
+          .update(readFileSync(join(outputDirectory, name)))
+          .digest('hex')
         expect(checksums).toContain(`${digest}  ${name}`)
       }
+      const macFeed = readFileSync(join(outputDirectory, 'latest-mac.yml'), 'utf8')
+      expect(macFeed).toContain('GooeyPi-0.2.0-arm64.zip')
+      expect(macFeed).toContain('GooeyPi-0.2.0-x64.zip')
     } finally {
       rmSync(directory, { recursive: true, force: true })
     }
@@ -401,7 +414,8 @@ describe('GitHub Release publication', () => {
       for (const [index, name] of expected.entries()) {
         const artifactDirectory = join(inputDirectory, `artifact-${index}`)
         mkdirSync(artifactDirectory)
-        writeFileSync(join(artifactDirectory, name), `asset ${index}`)
+        const updateTarget = name === 'latest-mac.yml' ? 'GooeyPi-0.2.0-arm64.zip' : name === 'latest-linux.yml' ? 'GooeyPi-0.2.0-linux-x86_64.AppImage' : 'GooeyPi-0.2.0-win-x64.exe'
+        writeFileSync(join(artifactDirectory, name), name.startsWith('latest') ? `version: 0.2.0\nfiles:\n  - url: ${updateTarget}\n    sha512: checksum-${index}\n` : `asset ${index}`)
       }
       const duplicateDirectory = join(inputDirectory, 'duplicate')
       mkdirSync(duplicateDirectory)


### PR DESCRIPTION
Adds a theme-purple automatic update control beside Settings, backed by electron-updater with startup and periodic release checks, automatic downloads, restart-to-install behavior, and GitHub release metadata publication.\n\nValidation:\n- npm run typecheck\n- npm run check\n- 62 focused updater/release/sidebar tests\n- full Electron E2E: 48 passed\n- post-rebase updater Electron smoke: passed