### PR TITLE
feat: add three-hour update checks and native menu

### DIFF
--- a/electron/main/application-menu.ts
+++ b/electron/main/application-menu.ts
@@ -1,0 +1,52 @@
+import { app, Menu, type MenuItemConstructorOptions } from 'electron'
+
+interface ApplicationMenuOptions {
+  checkForUpdates(): void
+  platform?: NodeJS.Platform
+  appName?: string
+}
+
+function updateMenuItem(checkForUpdates: () => void): MenuItemConstructorOptions {
+  return {
+    label: 'Check for Updates…',
+    click: () => checkForUpdates(),
+  }
+}
+
+export function buildApplicationMenuTemplate(options: ApplicationMenuOptions): MenuItemConstructorOptions[] {
+  const platform = options.platform ?? process.platform
+  const appName = options.appName ?? app.name
+  const standardMenus: MenuItemConstructorOptions[] = [
+    { role: 'fileMenu' },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+  ]
+
+  if (platform === 'darwin') {
+    return [{
+      label: appName,
+      submenu: [
+        { role: 'about' },
+        updateMenuItem(options.checkForUpdates),
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    }, ...standardMenus]
+  }
+
+  return [...standardMenus, {
+    role: 'help',
+    submenu: [updateMenuItem(options.checkForUpdates)],
+  }]
+}
+
+export function installApplicationMenu(options: ApplicationMenuOptions): void {
+  Menu.setApplicationMenu(Menu.buildFromTemplate(buildApplicationMenuTemplate(options)))
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -6,6 +6,7 @@ import { homedir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 import { BROWSER_PARTITION, type AppMeta, type AppUpdateState, type HarnessId, type PrimeEventEnvelope, type ProviderAuthEvent } from '../../src/types/api'
 import { AgentRpcManager, OMP_RPC_ADAPTER, PI_RPC_ADAPTER } from './agent-rpc'
+import { installApplicationMenu } from './application-menu'
 import { BrowserDownloadGuard } from './browser-downloads'
 import { installCrashGuards } from './crash-guard'
 import { CuaDriverService } from './cua-driver'
@@ -824,6 +825,7 @@ async function bootstrap(): Promise<void> {
       renderer.send('updates:changed', state)
     }
   })
+  installApplicationMenu({ appName: 'GooeyPi', checkForUpdates: () => { void updates.check() } })
   await ensureWindow()
   updates.start()
 }

--- a/electron/main/updates.ts
+++ b/electron/main/updates.ts
@@ -1,7 +1,7 @@
 import electronUpdater, { type AppUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater'
 import type { AppUpdateState } from '../../src/types/api'
 
-const DEFAULT_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+export const DEFAULT_CHECK_INTERVAL_MS = 3 * 60 * 60 * 1000
 const INITIAL_CHECK_DELAY_MS = 8_000
 
 export interface UpdateAdapter {

--- a/tests/backend/application-menu.test.ts
+++ b/tests/backend/application-menu.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electron = vi.hoisted(() => ({
+  buildFromTemplate: vi.fn((template: unknown) => ({ template })),
+  setApplicationMenu: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: { name: 'GooeyPi' },
+  Menu: electron,
+}))
+
+import { buildApplicationMenuTemplate, installApplicationMenu } from '../../electron/main/application-menu'
+
+function submenu(item: ReturnType<typeof buildApplicationMenuTemplate>[number] | undefined) {
+  return item && Array.isArray(item.submenu) ? item.submenu : []
+}
+
+beforeEach(() => {
+  electron.buildFromTemplate.mockClear()
+  electron.setApplicationMenu.mockClear()
+})
+
+describe('application update menu', () => {
+  it('puts Check for Updates in the app menu on macOS', () => {
+    const checkForUpdates = vi.fn()
+    const template = buildApplicationMenuTemplate({ platform: 'darwin', appName: 'GooeyPi', checkForUpdates })
+    const appMenu = template[0]
+    const updateItem = submenu(appMenu).find((item) => item.label === 'Check for Updates…')
+
+    expect(appMenu?.label).toBe('GooeyPi')
+    expect(updateItem).toBeDefined()
+    updateItem?.click?.(undefined as never, undefined as never, undefined as never)
+    expect(checkForUpdates).toHaveBeenCalledOnce()
+  })
+
+  it('puts Check for Updates in Help on Windows and Linux', () => {
+    for (const platform of ['win32', 'linux'] as const) {
+      const template = buildApplicationMenuTemplate({ platform, appName: 'GooeyPi', checkForUpdates: vi.fn() })
+      const helpMenu = template.at(-1)
+      expect(helpMenu?.role).toBe('help')
+      expect(submenu(helpMenu).map((item) => item.label)).toContain('Check for Updates…')
+    }
+  })
+
+  it('installs the native application menu', () => {
+    const checkForUpdates = vi.fn()
+    installApplicationMenu({ platform: 'linux', appName: 'GooeyPi', checkForUpdates })
+    expect(electron.buildFromTemplate).toHaveBeenCalledOnce()
+    expect(electron.setApplicationMenu).toHaveBeenCalledWith(electron.buildFromTemplate.mock.results[0]?.value)
+  })
+})

--- a/tests/backend/updates.test.ts
+++ b/tests/backend/updates.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { UpdateService, type UpdateAdapter } from '../../electron/main/updates'
+import { DEFAULT_CHECK_INTERVAL_MS, UpdateService, type UpdateAdapter } from '../../electron/main/updates'
 
 class FakeUpdater extends EventEmitter {
   autoDownload = false
@@ -26,6 +26,21 @@ describe('automatic update service', () => {
     await vi.advanceTimersByTimeAsync(25)
     expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
     await vi.advanceTimersByTimeAsync(100)
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(2)
+    service.dispose()
+  })
+
+  it('checks for a new release every three hours by default', async () => {
+    vi.useFakeTimers()
+    const updater = new FakeUpdater()
+    const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: true })
+
+    service.start()
+    await vi.advanceTimersByTimeAsync(8_000)
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS - 8_001)
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
     expect(updater.checkForUpdates).toHaveBeenCalledTimes(2)
     service.dispose()
   })

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -598,6 +598,13 @@ test.describe('Prime Work desktop smoke', () => {
     expect(bridge.type).toBe('object')
     expect(bridge.groups).toEqual(['agent', 'app', 'browser', 'git', 'heartbeats', 'pets', 'plugins', 'projects', 'providers', 'schedules', 'sessions', 'settings', 'terminal', 'updates', 'voice'])
     expect(bridge.voiceMethods).toContain('testSelfHosted')
+    const updateMenu = await app!.evaluate(({ Menu }) => {
+      const parents = Menu.getApplicationMenu()?.items ?? []
+      const parent = parents.find((item) => item.submenu?.items.some((child) => child.label === 'Check for Updates…'))
+      return { found: Boolean(parent), parent: parent?.label, platform: process.platform }
+    })
+    expect(updateMenu.found).toBe(true)
+    expect(updateMenu.parent).toBe(updateMenu.platform === 'darwin' ? 'GooeyPi' : 'Help')
     await expect(page.evaluate(() => window.prime.updates.getState())).resolves.toMatchObject({ phase: 'unsupported' })
     const credentialStatus = await page.evaluate(() => window.prime.voice.credentialStatus())
     expect(typeof credentialStatus.storage.available).toBe('boolean')


### PR DESCRIPTION
Changes automatic release polling from six hours to three hours and adds a native Check for Updates… command under the GooeyPi app menu on macOS and Help on Windows/Linux. The command uses the existing UpdateService pipeline, so discovery and download state render in the sidebar control.\n\nValidation:\n- npm run build\n- npm run check\n- focused updater and menu tests: 7 passed\n- Electron menu/sidebar smoke: passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/am-will/gooey-pi/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->