### PR TITLE
fix: keep stdin open during the pi model catalog probe

### DIFF
--- a/electron/main/providers-pi.ts
+++ b/electron/main/providers-pi.ts
@@ -187,7 +187,10 @@ function runModelProbe(executable: string, options: { timeoutMs: number; maxOutp
         ? `pi was terminated by ${signal} without answering the model catalog probe`
         : `pi exited with status ${code ?? -1} without answering the model catalog probe`)))
     })
-    child.stdin?.end(`${JSON.stringify({ id: PROBE_REQUEST_ID, type: PROBE_COMMAND })}\n`)
+    // Stdin stays open after the request: pi treats EOF as client-disconnect
+    // and can shut down before processing a request that arrived in the same
+    // flush. Every settle path terminates the child, so nothing lingers.
+    child.stdin?.write(`${JSON.stringify({ id: PROBE_REQUEST_ID, type: PROBE_COMMAND })}\n`)
   })
 }
 

--- a/tests/backend/providers-pi.test.ts
+++ b/tests/backend/providers-pi.test.ts
@@ -186,9 +186,25 @@ process.stdout.write(JSON.stringify({ type: 'response', id: '1', command: 'get_a
   })
 
   it('rejects a pi that exits without ever answering the probe', async () => {
-    const service = new PiModelCatalogService(fakePi("process.stdout.write('not json {{\\n')"))
+    // Exit explicitly after the flush: the probe holds stdin open, so a fake
+    // that merely stops writing would idle until the timeout instead.
+    const service = new PiModelCatalogService(fakePi("process.stdout.write('not json {{\\n', () => process.exit(0))"))
     await expect(service.catalog(true)).rejects.toThrow(/without answering the model catalog probe/)
     await expect(service.catalog()).rejects.toThrow(/without answering/)
+  })
+
+  it('keeps stdin open so a pi that exits on EOF can still answer the probe', async () => {
+    // Real pi (0.82.x) treats stdin EOF as client-disconnect and shuts down
+    // cleanly before processing a request that arrived in the same flush. This
+    // fake answers only after a delay, and exits the moment stdin ends.
+    const service = new PiModelCatalogService(fakePi(`
+process.stdin.on('end', () => process.exit(0))
+setTimeout(() => {
+  process.stdout.write(JSON.stringify({ type: 'response', id: '1', command: 'get_available_models', success: true, data: ${JSON.stringify(sampleCatalog)} }) + '\\n')
+}, 200)
+`))
+    const catalog = await service.catalog(true)
+    expect(catalog.models).toHaveLength(4)
   })
 
   it('rejects a matching response with an unexpected data shape', async () => {


### PR DESCRIPTION
## Problem

Opening Settings → Providers with the Pi harness selected fails with:

> Error invoking remote method 'providers:catalog': Error: pi exited with status 0 without answering the model catalog probe

The probe sends the `get_available_models` request with `stdin.end()`, which closes pi's stdin in the same flush. pi 0.82.x treats stdin EOF as client-disconnect and shuts down before processing the request, so the probe never gets an answer. Verified against pi 0.82.1: with stdin closed immediately the response never arrives; with stdin held open, the response frame arrives in about a second.

## Fix

Write the request with `stdin.write()` and leave stdin open. Every settle path already terminates the child (TERM then KILL), so nothing lingers.

## Tests

- New regression test: a fake pi that exits on stdin EOF and answers only after a delay. It fails with the exact production error before the fix and passes after.
- The existing exits-without-answering test's fake pi relied on stdin EOF to exit naturally; it now exits explicitly after flushing its output.