### PR TITLE
Canonicalize project metadata for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "gooeypi",
   "version": "0.1.8",
   "private": true,
-  "description": "A desktop workspace for OMP and Prime Agent",
+  "description": "A desktop workspace for Pi, OMP, and Prime Agent",
   "main": "out/main/index.js",
   "desktopName": "gooeypi.desktop",
   "author": {
     "name": "GooeyPi contributors",
     "email": "42459108+am-will@users.noreply.github.com"
   },
-  "homepage": "https://github.com/am-will/prime-work",
+  "homepage": "https://github.com/am-will/gooey-pi",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -115,7 +115,7 @@
     },
     "linux": {
       "category": "Development",
-      "synopsis": "A desktop workspace for OMP and Prime Agent",
+      "synopsis": "A desktop workspace for Pi, OMP, and Prime Agent",
       "syncDesktopName": true,
       "target": [
         "AppImage",

--- a/tests/release-scripts.test.ts
+++ b/tests/release-scripts.test.ts
@@ -526,7 +526,10 @@ describe('post-package verification helpers', () => {
   test('keeps every platform native unpack allowlist exact and architecture-specific', () => {
     const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
     expect(packageJson.author).toEqual({ name: 'GooeyPi contributors', email: '42459108+am-will@users.noreply.github.com' })
-    expect(packageJson.homepage).toBe('https://github.com/am-will/prime-work')
+    expect(packageJson.description).toBe('A desktop workspace for Pi, OMP, and Prime Agent')
+    expect(packageJson.homepage).toBe('https://github.com/am-will/gooey-pi')
+    expect(packageJson.build.productName).toBe('GooeyPi')
+    expect(packageJson.build.appId).toBe('app.gooeypi.desktop')
     expect(packageJson.desktopName).toBe('gooeypi.desktop')
     expect(packageJson.build.linux.synopsis).toBe(packageJson.description)
     expect(packageJson.build.linux.syncDesktopName).toBe(true)


### PR DESCRIPTION
@am-will — this fixes the unconditional metadata portion of the Homebrew Cask
readiness work.

- use the canonical `am-will/gooey-pi` homepage
- describe all three supported harnesses consistently
- keep the Linux package synopsis aligned with the package description
- lock those values in the existing release-script test

The minimum macOS and bundle-verification changes remain separate until the
support floor is confirmed in the tracking issue.

Validation:

- `npx vitest run tests/release-scripts.test.ts -t "keeps every platform native unpack allowlist exact and architecture-specific"`
- `npm run typecheck`
- `npm run check`