### PR TITLE
Require consent before downloading updates

### DIFF
--- a/electron/main/ipc.ts
+++ b/electron/main/ipc.ts
@@ -187,7 +187,7 @@ export function registerIpc(services: Services, expectedRendererUrl: string): Ip
   })
   handle('updates:get-state', () => services.updates.getState())
   handle('updates:check', () => services.updates.check())
-  handle('updates:install', () => services.updates.install())
+  handle('updates:download-and-install', () => services.updates.downloadAndInstall())
 
   handle('projects:list', (_event, harness) => projectsFor(requireHarness(harness)).list())
   handle('projects:list-files', (_event, root, harness) => projectsFor(requireHarness(harness)).listFiles(root))

--- a/electron/main/updates.ts
+++ b/electron/main/updates.ts
@@ -12,6 +12,7 @@ export interface UpdateAdapter {
   on(event: 'download-progress', listener: (progress: ProgressInfo) => void): this
   on(event: 'error', listener: (error: Error) => void): this
   checkForUpdates(): Promise<unknown>
+  downloadUpdate(): Promise<unknown>
   quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
 }
 
@@ -58,6 +59,8 @@ export class UpdateService {
   private state: AppUpdateState
   private sink: ((state: AppUpdateState) => void) | null = null
   private checkPromise: Promise<AppUpdateState> | null = null
+  private downloadPromise: Promise<boolean> | null = null
+  private installAfterDownload = false
   private interval: ReturnType<typeof globalThis.setInterval> | null = null
   private initialTimer: ReturnType<typeof globalThis.setTimeout> | null = null
   private readonly setIntervalFn: typeof globalThis.setInterval
@@ -71,8 +74,8 @@ export class UpdateService {
     this.setTimeoutFn = options.setTimeout ?? globalThis.setTimeout
     if (!options.enabled) return
 
-    updater.autoDownload = true
-    updater.autoInstallOnAppQuit = true
+    updater.autoDownload = false
+    updater.autoInstallOnAppQuit = false
     updater.on('checking-for-update', () => this.publish({ phase: 'checking' }))
     updater.on('update-available', (info) => this.publish({ phase: 'available', version: info.version }))
     updater.on('download-progress', (progress) => this.publish({
@@ -80,9 +83,17 @@ export class UpdateService {
       version: this.state.version,
       percent: Math.max(0, Math.min(100, Math.round(progress.percent))),
     }))
-    updater.on('update-downloaded', (info) => this.publish({ phase: 'downloaded', version: info.version }))
+    updater.on('update-downloaded', (info) => {
+      this.publish({ phase: 'downloaded', version: info.version })
+      if (!this.installAfterDownload) return
+      this.installAfterDownload = false
+      this.updater.quitAndInstall(false, true)
+    })
     updater.on('update-not-available', (info) => this.publish({ phase: 'not-available', version: info.version }))
-    updater.on('error', (error) => this.publish({ phase: 'error', message: errorMessage(error) }))
+    updater.on('error', (error) => {
+      this.installAfterDownload = false
+      this.publish({ phase: 'error', message: errorMessage(error) })
+    })
   }
 
   start(): void {
@@ -126,10 +137,26 @@ export class UpdateService {
     return this.checkPromise
   }
 
-  install(): boolean {
-    if (!this.options.enabled || this.state.phase !== 'downloaded') return false
-    this.updater.quitAndInstall(false, true)
-    return true
+  downloadAndInstall(): Promise<boolean> {
+    if (!this.options.enabled) return Promise.resolve(false)
+    if (this.state.phase === 'downloaded') {
+      this.updater.quitAndInstall(false, true)
+      return Promise.resolve(true)
+    }
+    if (this.state.phase !== 'available') return Promise.resolve(false)
+    if (this.downloadPromise) return this.downloadPromise
+
+    this.installAfterDownload = true
+    this.publish({ phase: 'downloading', version: this.state.version, percent: 0 })
+    this.downloadPromise = this.updater.downloadUpdate()
+      .then(() => true)
+      .catch((error) => {
+        this.installAfterDownload = false
+        this.publish({ phase: 'error', message: errorMessage(error) })
+        return false
+      })
+      .finally(() => { this.downloadPromise = null })
+    return this.downloadPromise
   }
 
   private publish(state: AppUpdateState): void {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -20,7 +20,7 @@ const api: PrimeWorkApi = {
   updates: {
     getState: () => ipcRenderer.invoke('updates:get-state'),
     check: () => ipcRenderer.invoke('updates:check'),
-    install: () => ipcRenderer.invoke('updates:install'),
+    downloadAndInstall: () => ipcRenderer.invoke('updates:download-and-install'),
     onChanged: (callback) => subscribe<AppUpdateState>('updates:changed', callback),
   },
   projects: {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -120,7 +120,7 @@ function updateControlCopy(state: AppUpdateState): { label: string; title: strin
   const version = state.version ? ` ${state.version}` : ''
   switch (state.phase) {
     case 'checking': return { label: 'Checking for updates', title: 'Checking GitHub Releases for a new GooeyPi version' }
-    case 'available': return { label: `Update${version} found`, title: `GooeyPi${version} is downloading automatically` }
+    case 'available': return { label: `Download${version}`, title: `Download and restart GooeyPi${version}` }
     case 'downloading': return { label: `Downloading${version} · ${state.percent ?? 0}%`, title: `Downloading GooeyPi${version}` }
     case 'downloaded': return { label: `Restart for${version}`, title: `Restart GooeyPi and install version${version}` }
     case 'not-available': return { label: 'GooeyPi is up to date', title: 'Check again for a new GooeyPi release' }
@@ -162,6 +162,7 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
   const [renameValue, setRenameValue] = useState('')
   const [archiveTarget, setArchiveTarget] = useState<SessionRecord | null>(null)
   const [removeTarget, setRemoveTarget] = useState<ProjectRecord | null>(null)
+  const [confirmUpdate, setConfirmUpdate] = useState(false)
   const { activeSessions, sessionsByProject } = useMemo(() => indexSidebarSessions(projects, sessions), [projects, sessions])
   const needsAttention = (session: SessionRecord) => {
     const signature = sessionAttentionSignature(session)
@@ -173,7 +174,7 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
   const commandsShortcut = shortcutLabel(platform, ['Primary', 'K'])
   const settingsShortcut = shortcutLabel(platform, ['Primary', ','])
   const updateCopy = updateControlCopy(updateState)
-  const updateBusy = updateState.phase === 'checking' || updateState.phase === 'available' || updateState.phase === 'downloading'
+  const updateBusy = updateState.phase === 'checking' || updateState.phase === 'downloading'
   const updateVisible = updateState.phase === 'available' || updateState.phase === 'downloading' || updateState.phase === 'downloaded'
   useEffect(() => {
     if (!harnessMenuOpen) return
@@ -326,7 +327,7 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
       <div className="sidebar__footer">
         <button type="button" title="Commands" onClick={onOpenPalette}><Search size={15} /><span>Commands</span><kbd>{commandsShortcut}</kbd></button>
         {updateVisible ? (
-          <button type="button" className={`sidebar-update sidebar-update--${updateState.phase}`} title={updateCopy.title} aria-label={updateCopy.title} aria-live="polite" disabled={updateBusy} onClick={() => { void onUpdateAction?.() }}>
+          <button type="button" className={`sidebar-update sidebar-update--${updateState.phase}`} title={updateCopy.title} aria-label={updateCopy.title} aria-live="polite" disabled={updateBusy} onClick={() => setConfirmUpdate(true)}>
             <span className="sidebar-update__icon" style={{ '--update-progress': `${updateState.percent ?? 0}%` } as CSSProperties}><Download size={12} /></span>
             <span>{updateCopy.label}</span>
           </button>
@@ -335,6 +336,7 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
       </div>
       {renameTarget ? <Modal title="Rename session" onClose={() => setRenameTarget(null)} footer={<><button type="button" className="button" onClick={() => setRenameTarget(null)}>Cancel</button><button type="button" className="button button--primary" disabled={!renameValue.trim()} onClick={() => { const target = renameTarget; const title = renameValue.trim(); setRenameTarget(null); void onRenameSession(target, title) }}>Rename</button></>}><label className="field"><span>Session name</span><input autoFocus value={renameValue} maxLength={200} onChange={(event) => setRenameValue(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && renameValue.trim()) { event.preventDefault(); const target = renameTarget; const title = renameValue.trim(); setRenameTarget(null); void onRenameSession(target, title) } }}/></label></Modal> : null}
       {removeTarget ? <Modal title="Remove project" onClose={() => setRemoveTarget(null)} footer={<><button type="button" className="button" onClick={() => setRemoveTarget(null)}>Cancel</button><button type="button" className="button button--danger" onClick={() => { const target = removeTarget; setRemoveTarget(null); onRemoveProject(target) }}>Remove</button></>}><p>Remove “{removeTarget.name}” from {HARNESS_PRODUCT_NAMES[activeHarness]}? The folder and saved sessions will not be deleted.</p></Modal> : null}
+      {confirmUpdate ? <Modal title="Download and Restart GooeyPi?" onClose={() => setConfirmUpdate(false)} footer={<><button type="button" className="button" onClick={() => setConfirmUpdate(false)}>No</button><button type="button" className="button button--primary" onClick={() => { setConfirmUpdate(false); void onUpdateAction?.() }}>Yes</button></>}><p>GooeyPi will download the update, close, and restart when it is ready.</p></Modal> : null}
     </aside>
   )
 }

--- a/src/hooks/useAppUpdates.ts
+++ b/src/hooks/useAppUpdates.ts
@@ -25,7 +25,7 @@ export function useAppUpdates(bridge: PrimeWorkApi | null, reportError: (error: 
   const act = useCallback(async () => {
     if (!bridge) return
     try {
-      if (state.phase === 'downloaded') await bridge.updates.install()
+      if (state.phase === 'available' || state.phase === 'downloaded') await bridge.updates.downloadAndInstall()
       else setState(await bridge.updates.check())
     } catch (error) {
       reportError(error)

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -653,7 +653,7 @@ export interface PrimeWorkApi {
   updates: {
     getState(): Promise<AppUpdateState>
     check(): Promise<AppUpdateState>
-    install(): Promise<boolean>
+    downloadAndInstall(): Promise<boolean>
     onChanged(callback: (state: AppUpdateState) => void): () => void
   }
   projects: {

--- a/tests/backend/preload-projects.test.ts
+++ b/tests/backend/preload-projects.test.ts
@@ -39,15 +39,15 @@ describe('preload project worktree bridge', () => {
     ])
   })
 
-  it('exposes update status, check, and install calls', async () => {
-    const api = electronMocks.api as { updates: { getState(): Promise<unknown>; check(): Promise<unknown>; install(): Promise<unknown> } }
+  it('exposes update status, check, and consented download-and-install calls', async () => {
+    const api = electronMocks.api as { updates: { getState(): Promise<unknown>; check(): Promise<unknown>; downloadAndInstall(): Promise<unknown> } }
     await api.updates.getState()
     await api.updates.check()
-    await api.updates.install()
+    await api.updates.downloadAndInstall()
     expect(electronMocks.ipcRenderer.invoke.mock.calls).toEqual([
       ['updates:get-state'],
       ['updates:check'],
-      ['updates:install'],
+      ['updates:download-and-install'],
     ])
   })
 })

--- a/tests/backend/updates.test.ts
+++ b/tests/backend/updates.test.ts
@@ -3,9 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_CHECK_INTERVAL_MS, manualUpdateNotification, UpdateService, type UpdateAdapter } from '../../electron/main/updates'
 
 class FakeUpdater extends EventEmitter {
-  autoDownload = false
-  autoInstallOnAppQuit = false
+  autoDownload = true
+  autoInstallOnAppQuit = true
   checkForUpdates = vi.fn(async () => undefined)
+  downloadUpdate = vi.fn(async (): Promise<void> => undefined)
   quitAndInstall = vi.fn()
 }
 
@@ -21,12 +22,12 @@ describe('automatic update service', () => {
     expect(manualUpdateNotification({ phase: 'downloaded', version: '0.2.0' })).toMatchObject({ type: 'info', message: 'GooeyPi Update Available' })
   })
 
-  it('automatically checks installed builds and configures download-on-discovery', async () => {
+  it('automatically checks installed builds without downloading or installing on quit', async () => {
     vi.useFakeTimers()
     const updater = new FakeUpdater()
     const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: true, initialCheckDelayMs: 25, checkIntervalMs: 100 })
-    expect(updater.autoDownload).toBe(true)
-    expect(updater.autoInstallOnAppQuit).toBe(true)
+    expect(updater.autoDownload).toBe(false)
+    expect(updater.autoInstallOnAppQuit).toBe(false)
 
     service.start()
     await vi.advanceTimersByTimeAsync(25)
@@ -51,22 +52,42 @@ describe('automatic update service', () => {
     service.dispose()
   })
 
-  it('reports discovery, progress, completion, and installs only a downloaded update', () => {
+  it('does not download or restart until the available update is explicitly accepted', async () => {
     const updater = new FakeUpdater()
     const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: true })
     const changed = vi.fn()
     service.setEventSink(changed)
 
     updater.emit('update-available', { version: '0.2.0' })
+    expect(service.getState()).toEqual({ phase: 'available', version: '0.2.0' })
+    expect(updater.downloadUpdate).not.toHaveBeenCalled()
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+
+    let finishDownload!: () => void
+    updater.downloadUpdate.mockImplementation(() => new Promise<void>((resolve) => { finishDownload = resolve }))
+    const accepted = service.downloadAndInstall()
+    expect(service.getState()).toEqual({ phase: 'downloading', version: '0.2.0', percent: 0 })
+    expect(updater.downloadUpdate).toHaveBeenCalledOnce()
+
     updater.emit('download-progress', { percent: 48.6 })
     expect(service.getState()).toEqual({ phase: 'downloading', version: '0.2.0', percent: 49 })
-    expect(service.install()).toBe(false)
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
 
     updater.emit('update-downloaded', { version: '0.2.0' })
     expect(service.getState()).toEqual({ phase: 'downloaded', version: '0.2.0' })
-    expect(service.install()).toBe(true)
     expect(updater.quitAndInstall).toHaveBeenCalledWith(false, true)
+    finishDownload()
+    await expect(accepted).resolves.toBe(true)
     expect(changed).toHaveBeenCalled()
+  })
+
+  it('does not restart for a downloaded event that was not user-approved', () => {
+    const updater = new FakeUpdater()
+    const service = new UpdateService(updater as unknown as UpdateAdapter, { enabled: true })
+
+    updater.emit('update-downloaded', { version: '0.2.0' })
+    expect(service.getState()).toEqual({ phase: 'downloaded', version: '0.2.0' })
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
   })
 
   it('keeps an active release state while a manual check is requested', async () => {
@@ -84,6 +105,6 @@ describe('automatic update service', () => {
     service.start()
     await expect(service.check()).resolves.toMatchObject({ phase: 'unsupported' })
     expect(updater.checkForUpdates).not.toHaveBeenCalled()
-    expect(service.install()).toBe(false)
+    await expect(service.downloadAndInstall()).resolves.toBe(false)
   })
 })

--- a/tests/frontend/sidebar-archive.test.tsx
+++ b/tests/frontend/sidebar-archive.test.tsx
@@ -49,12 +49,12 @@ async function rightClick(element: Element) {
 }
 
 describe('sidebar project context menu', () => {
-  it('shows the automatic release control beside Settings and invokes its current action', async () => {
+  it('requires confirmation before downloading and restarting an available update', async () => {
     const onUpdateAction = vi.fn()
     await act(async () => {
       root.render(
         <Sidebar
-          projects={[project]} sessions={[session]} activeView="session" updateState={{ phase: 'downloaded', version: '0.2.0' }} onUpdateAction={onUpdateAction}
+          projects={[project]} sessions={[session]} activeView="session" updateState={{ phase: 'available', version: '0.2.0' }} onUpdateAction={onUpdateAction}
           onSelectProject={noop} onSelectSession={noop} onNavigate={noop} onNewSession={noop} onAddProject={noop} onRemoveProject={noop}
           onClose={noop} onOpenPalette={noop} onRenameSession={async () => undefined} onArchiveSession={async () => undefined}
         />,
@@ -65,9 +65,15 @@ describe('sidebar project context menu', () => {
     const settings = container.querySelector('.sidebar__footer button[title="Settings"]')
     expect(update).not.toBeNull()
     expect(update?.nextElementSibling).toBe(settings)
-    expect(update?.textContent).toContain('Restart for 0.2.0')
+    expect(update?.textContent).toContain('Download 0.2.0')
     expect(update?.querySelector('.lucide-download')).not.toBeNull()
     await press(update!)
+    expect(onUpdateAction).not.toHaveBeenCalled()
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).toContain('Download and Restart GooeyPi?')
+
+    const yes = [...document.body.querySelectorAll<HTMLButtonElement>('.modal__footer button')].find((button) => button.textContent === 'Yes')
+    expect(yes).toBeDefined()
+    await press(yes!)
     expect(onUpdateAction).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## Summary
- keep automatic update checks but disable automatic downloads and install-on-quit
- show a Download action for available versions and require the exact confirmation "Download and Restart GooeyPi?"
- download only after Yes, then restart automatically when the package is ready

## Verification
- npm test (117 files, 1060 tests)
- npm run test:e2e (51 tests)
- npm run typecheck
- npm run lint
- focused updater/preload/sidebar tests (18 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/am-will/gooey-pi/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->