### PR TITLE
fix: stabilize questionnaire navigation and collaboration polling

### DIFF
--- a/electron/main/collaboration/agent-bridge.ts
+++ b/electron/main/collaboration/agent-bridge.ts
@@ -20,6 +20,17 @@ const WAIT_TRANSCRIPT_POLL_MS = 1_000
 const WAIT_RUNTIME_POLL_MS = 250
 const MAX_ACTIVE_WAITS_PER_TOKEN = 2
 
+async function delayUntil(targetTime: number): Promise<void> {
+  while (true) {
+    const remaining = targetTime - Date.now()
+    if (remaining <= 0) return
+    await new Promise<void>((resolveDelay) => {
+      const timer = setTimeout(resolveDelay, remaining)
+      timer.unref()
+    })
+  }
+}
+
 interface CollaborationSessionService {
   list(projectPath?: unknown, includeArchived?: unknown, force?: unknown): Promise<SessionRecord[]>
   read(filePath: unknown): Promise<TranscriptMessage[]>
@@ -393,18 +404,18 @@ export class AgentCollaborationBridge extends CapabilityBridge {
     const afterCursor = rawCursor === undefined ? undefined : requireString(rawCursor, 'after_cursor', { min: 1, max: 128, trim: true })
     const timeoutMs = rawTimeout === undefined ? 15_000 : requireInteger(rawTimeout, 'timeout_ms', 0, MAX_WAIT_MS)
     const startedAt = Date.now()
+    const deadline = startedAt + timeoutMs
     let snapshot = await this.snapshot(target)
-    while (Date.now() - startedAt < timeoutMs) {
+    while (Date.now() < deadline) {
       const runtime = target.manager.getForSession(target.session.filePath)
       const idle = !runtime || (!runtime.isStreaming && !runtime.isCompacting && !runtime.sessionActions?.active && (runtime.sessionActions?.queuedCount ?? 0) === 0)
       if (idle && (afterCursor === undefined || snapshot.cursor !== afterCursor)) return { ...snapshot, timed_out: false }
-      await new Promise<void>((resolveDelay) => {
-        // Busy runtimes need only a cheap in-memory state probe. Transcript
-        // reads resume at a bounded cadence once the target is idle/offline.
-        const remaining = Math.max(0, timeoutMs - (Date.now() - startedAt))
-        const timer = setTimeout(resolveDelay, Math.min(remaining, idle ? WAIT_TRANSCRIPT_POLL_MS : WAIT_RUNTIME_POLL_MS))
-        timer.unref()
-      })
+      // Busy runtimes need only a cheap in-memory state probe. Transcript
+      // reads resume at a bounded cadence once the target is idle/offline.
+      // Re-arm an early timer wake until the intended poll instant so a short
+      // wait cannot perform multiple transcript reads at its deadline.
+      const nextPollAt = Math.min(deadline, Date.now() + (idle ? WAIT_TRANSCRIPT_POLL_MS : WAIT_RUNTIME_POLL_MS))
+      await delayUntil(nextPollAt)
       if (idle) snapshot = await this.snapshot(target)
     }
     return { ...snapshot, timed_out: true }

--- a/electron/main/collaboration/agent-bridge.ts
+++ b/electron/main/collaboration/agent-bridge.ts
@@ -416,7 +416,10 @@ export class AgentCollaborationBridge extends CapabilityBridge {
       // wait cannot perform multiple transcript reads at its deadline.
       const nextPollAt = Math.min(deadline, Date.now() + (idle ? WAIT_TRANSCRIPT_POLL_MS : WAIT_RUNTIME_POLL_MS))
       await delayUntil(nextPollAt)
-      if (idle) snapshot = await this.snapshot(target)
+      if (idle) {
+        snapshot = await this.snapshot(target)
+        if (afterCursor === undefined || snapshot.cursor !== afterCursor) return { ...snapshot, timed_out: false }
+      }
     }
     return { ...snapshot, timed_out: true }
   }

--- a/scripts/release/install-app-deps.mjs
+++ b/scripts/release/install-app-deps.mjs
@@ -1,12 +1,25 @@
 #!/usr/bin/env node
+import { pathToFileURL } from 'node:url'
 import { runCommand } from './lib.mjs'
 
-const env = { ...process.env }
-if (process.platform === 'darwin' && !env.PYTHON) env.PYTHON = '/usr/bin/python3'
+/**
+ * @param {(command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => unknown} run
+ * @param {NodeJS.ProcessEnv} sourceEnvironment
+ * @param {NodeJS.Platform} platform
+ */
+export function installAppDependencies(run = runCommand, sourceEnvironment = process.env, platform = process.platform) {
+  const env = { ...sourceEnvironment }
+  if (platform === 'darwin' && !env.PYTHON) env.PYTHON = '/usr/bin/python3'
 
-try {
-  runCommand('electron-builder', ['install-app-deps'], { env })
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error))
-  process.exitCode = 1
+  run('install-electron', [], { env })
+  run('electron-builder', ['install-app-deps'], { env })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    installAppDependencies()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
 }

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -14,6 +14,9 @@ export const MINIMUM_NODE = [22, 12, 0]
  */
 export function resolveCommandInvocation(command, args, platform = process.platform, env = process.env) {
   if (command === 'node') return { file: process.execPath, args: [...args], shell: false }
+  if (command === 'install-electron') {
+    return { file: process.execPath, args: [localRequire.resolve('electron/install.js'), ...args], shell: false }
+  }
   if (command === 'electron-builder') {
     return { file: process.execPath, args: [localRequire.resolve('electron-builder/cli.js'), ...args], shell: false }
   }

--- a/src/components/ExtensionUiModal.tsx
+++ b/src/components/ExtensionUiModal.tsx
@@ -79,6 +79,7 @@ export function ExtensionUiModal({ request, onRespond, platform = 'darwin' }: Ex
     const container = questionnaireRef.current
     if (!container || container.contains(document.activeElement)) return
     const focusTarget = container.querySelector<HTMLElement>('.extension-question__options button')
+      ?? container.querySelector<HTMLElement>('.extension-questionnaire__progress button.is-active')
     focusTarget?.focus()
   }, [request.id, request.method === 'questionnaire' ? request.complete : false, questionIndex])
 
@@ -219,11 +220,11 @@ export function ExtensionUiModal({ request, onRespond, platform = 'darwin' }: Ex
               ) : null}
               <div className="extension-questionnaire__progress" aria-label="Question progress">
                 {request.questions.map((question, index) => (
-                  <button type="button" key={question.id} className={questionIndex === index ? 'is-active' : ''} onClick={() => navigateQuestion(index)}>
+                  <button type="button" key={question.id} aria-current={questionIndex === index ? 'step' : undefined} className={questionIndex === index ? 'is-active' : ''} onClick={() => navigateQuestion(index)}>
                     {answeredByQuestion[question.id] ? '✓' : '○'} {index + 1}
                   </button>
                 ))}
-                <button type="button" className={questionIndex === request.questions.length ? 'is-active' : ''} onClick={() => navigateQuestion(request.questions.length)}>✓ Submit</button>
+                <button type="button" aria-current={questionIndex === request.questions.length ? 'step' : undefined} className={questionIndex === request.questions.length ? 'is-active' : ''} onClick={() => navigateQuestion(request.questions.length)}>✓ Submit</button>
               </div>
               {activeQuestion ? (
                 <div className="extension-questionnaire__question">

--- a/tests/backend/agent-collaboration-bridge.test.ts
+++ b/tests/backend/agent-collaboration-bridge.test.ts
@@ -316,6 +316,26 @@ describe('AgentCollaborationBridge', () => {
     expect(primeSessions.read.mock.calls.length - readsBefore).toBeLessThanOrEqual(2)
   })
 
+  it('re-arms an early timeout wake without polling the transcript early', async () => {
+    const { call, primeSessions } = await fixture()
+    const read = await call('read', { target_session_id: target.id })
+    const cursor = (read.body.result as Record<string, unknown>).cursor
+    const readsBefore = primeSessions.read.mock.calls.length
+    const nativeSetTimeout = globalThis.setTimeout
+    const timer = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+      const requested = Number(delay ?? 0)
+      return nativeSetTimeout(callback, requested > 25 && requested <= 150 ? requested - 25 : requested, ...args)
+    }) as typeof setTimeout)
+
+    try {
+      const completed = await call('wait', { target_session_id: target.id, after_cursor: cursor, timeout_ms: 150 })
+      expect(completed.body.result).toMatchObject({ timed_out: true })
+      expect(primeSessions.read.mock.calls.length - readsBefore).toBeLessThanOrEqual(2)
+    } finally {
+      timer.mockRestore()
+    }
+  })
+
   it('wakes an offline target while rejecting missing source scope and invalid tokens', async () => {
     const { bridge, call, environment } = await fixture(false)
     const offline = await call('send', { target_session_id: target.id, message: 'Hello' })

--- a/tests/backend/agent-collaboration-bridge.test.ts
+++ b/tests/backend/agent-collaboration-bridge.test.ts
@@ -336,6 +336,28 @@ describe('AgentCollaborationBridge', () => {
     }
   })
 
+  it('reports a transcript change found by the final deadline snapshot', async () => {
+    const changedTranscript: TranscriptMessage[] = [
+      ...defaultTargetTranscript,
+      { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'The deadline update is ready.' }] },
+    ]
+    const { call, primeSessions } = await fixture()
+    let reads = 0
+    primeSessions.read.mockImplementation(async () => {
+      reads += 1
+      return reads >= 3 ? changedTranscript : defaultTargetTranscript
+    })
+    const read = await call('read', { target_session_id: target.id })
+    const cursor = (read.body.result as Record<string, unknown>).cursor
+
+    const completed = await call('wait', { target_session_id: target.id, after_cursor: cursor, timeout_ms: 50 })
+
+    expect(completed.body.result).toMatchObject({ timed_out: false })
+    expect((completed.body.result as Record<string, unknown>).messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'a2', text: 'The deadline update is ready.' }),
+    ]))
+  })
+
   it('wakes an offline target while rejecting missing source scope and invalid tokens', async () => {
     const { bridge, call, environment } = await fixture(false)
     const offline = await call('send', { target_session_id: target.id, message: 'Hello' })

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1586,6 +1586,13 @@ test.describe('Prime Work desktop smoke', () => {
     await expect(dialog).toContainText('Question 2 of 2')
 
     await dialog.getByRole('option', { name: 'Safety' }).click()
+    await expect(dialog).toContainText('Submit answers')
+    const submitStep = dialog.locator('.extension-questionnaire__progress button').last()
+    await expect(submitStep).toHaveAttribute('aria-current', 'step')
+    await expect(submitStep).toBeFocused()
+    await page.keyboard.press('Control+ArrowLeft')
+    await expect(dialog).toContainText('Question 2 of 2')
+    await expect(dialog.getByRole('option', { name: 'Safety' })).toHaveAttribute('aria-selected', 'true')
     await page.keyboard.press('Control+ArrowLeft')
     await expect(dialog).toContainText('Question 1 of 2')
     await expect(dialog.getByRole('textbox', { name: 'Additional context' })).toHaveValue('For the pilot')

--- a/tests/frontend/extension-ui-modal.test.tsx
+++ b/tests/frontend/extension-ui-modal.test.tsx
@@ -53,6 +53,11 @@ function pressKey(target: HTMLElement, init: KeyboardEventInit): KeyboardEvent {
   return event
 }
 
+async function clickButton(button: HTMLButtonElement): Promise<void> {
+  button.focus()
+  await act(async () => { button.click() })
+}
+
 describe('extension questionnaire keyboard handling', () => {
   it('leaves Tab to the focus trap instead of hijacking it for question navigation', async () => {
     await act(async () => { root.render(<ExtensionUiModal request={request} onRespond={vi.fn()} />) })
@@ -75,6 +80,26 @@ describe('extension questionnaire keyboard handling', () => {
     expect(currentQuestionTitle()).toBe('Pick a language')
     pressKey(questionnaireElement(), { key: 'PageUp' })
     expect(currentQuestionTitle()).toBe('Pick a framework')
+  })
+
+  it('keeps navigation focused after the final option auto-advances to the submit summary', async () => {
+    await act(async () => { root.render(<ExtensionUiModal request={request} onRespond={vi.fn()} />) })
+    await clickButton(questionnaireElement().querySelector<HTMLButtonElement>('.extension-question__options button')!)
+    expect(currentQuestionTitle()).toBe('Pick a language')
+
+    await clickButton(questionnaireElement().querySelector<HTMLButtonElement>('.extension-question__options button')!)
+    expect(currentQuestionTitle()).toBe('')
+    const summaryProgress = questionnaireElement().querySelector<HTMLButtonElement>('.extension-questionnaire__progress button:last-child')!
+    expect(document.activeElement).toBe(summaryProgress)
+    expect(summaryProgress.getAttribute('aria-current')).toBe('step')
+
+    pressKey(document.activeElement as HTMLElement, { key: 'ArrowLeft', ctrlKey: true })
+    expect(currentQuestionTitle()).toBe('Pick a language')
+
+    await clickButton(summaryProgress)
+    expect(currentQuestionTitle()).toBe('')
+    pressKey(document.activeElement as HTMLElement, { key: 'PageUp' })
+    expect(currentQuestionTitle()).toBe('Pick a language')
   })
 
   it('keeps caret movement in the context field when pressing bare arrow keys', async () => {

--- a/tests/frontend/renderer-concurrency.test.tsx
+++ b/tests/frontend/renderer-concurrency.test.tsx
@@ -334,17 +334,26 @@ describe('agent event frame queue', () => {
   const messageText = (state: ReturnType<typeof useWorkspaceRuntime>) => (state.messages[0]?.parts[0] as { text?: string } | undefined)?.text ?? ''
 
   it('cancels the pending animation frame before a synchronous flush', async () => {
+    const pendingFrame = 417
+    const rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => pendingFrame)
     const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame')
-    const read = vi.fn().mockResolvedValue([message('loaded:')])
-    const workspace = mountWorkspace(read)
-    await act(async () => { workspace.render(); await Promise.resolve(); await Promise.resolve() })
-    const state = workspace.state()
-    await act(async () => { state.attachRuntime(runtime, 0) })
-    await act(async () => { state.queueAgentEvent(delta('live')) })
-    const cancelledBefore = cancelSpy.mock.calls.length
-    await act(async () => { state.reconcileTranscriptForEvent(runtime.runtimeId, { type: 'agent_end' }); await Promise.resolve() })
-    expect(cancelSpy.mock.calls.length).toBeGreaterThan(cancelledBefore)
-    expect(messageText(workspace.state())).toBe('loaded:')
+    try {
+      const read = vi.fn().mockResolvedValue([message('loaded:')])
+      const workspace = mountWorkspace(read)
+      await act(async () => { workspace.render(); await Promise.resolve(); await Promise.resolve() })
+      const state = workspace.state()
+      await act(async () => { state.attachRuntime(runtime, 0) })
+      await act(async () => { state.queueAgentEvent(delta('live')) })
+      expect(rafSpy).toHaveBeenCalledTimes(1)
+
+      await act(async () => { state.reconcileTranscriptForEvent(runtime.runtimeId, { type: 'agent_end' }); await Promise.resolve() })
+
+      expect(cancelSpy).toHaveBeenCalledWith(pendingFrame)
+      expect(messageText(workspace.state())).toBe('loaded:')
+    } finally {
+      cancelSpy.mockRestore()
+      rafSpy.mockRestore()
+    }
   })
 
   it('falls back to an authoritative read on the next visibilitychange after the queue bound is exceeded', async () => {

--- a/tests/release-scripts.test.ts
+++ b/tests/release-scripts.test.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
+import { installAppDependencies } from '../scripts/release/install-app-deps.mjs'
 import {
   artifactArchitectures,
   assertArchitectureCoverage,
@@ -1022,6 +1023,11 @@ describe('cross-platform packaging repair', () => {
 
   test('resolves release-script commands to Windows-safe spawns', () => {
     expect(resolveCommandInvocation('node', ['scripts/release/verify.mjs'])).toEqual({ file: process.execPath, args: ['scripts/release/verify.mjs'], shell: false })
+    const electronInstaller = resolveCommandInvocation('install-electron', [])
+    expect(electronInstaller.file).toBe(process.execPath)
+    expect(electronInstaller.args).toHaveLength(1)
+    expect(electronInstaller.args[0]).toMatch(/node_modules[\\/]electron[\\/]install\.js$/)
+    expect(electronInstaller.shell).toBe(false)
     const builder = resolveCommandInvocation('electron-builder', ['install-app-deps'])
     expect(builder.file).toBe(process.execPath)
     expect(builder.shell).toBe(false)
@@ -1034,6 +1040,22 @@ describe('cross-platform packaging repair', () => {
     expect(npmViaLifecycle).toEqual({ file: process.execPath, args: ['C:/npm/npm-cli.js', 'run', 'release:verify'], shell: false })
     expect(resolveCommandInvocation('npm', ['ci'], 'win32', {})).toEqual({ file: 'npm.cmd', args: ['ci'], shell: true })
     expect(resolveCommandInvocation('npm', ['ci'], 'darwin', {})).toEqual({ file: 'npm', args: ['ci'], shell: false })
+  })
+
+  test('installs Electron before rebuilding native app dependencies', () => {
+    const calls: Array<{ command: string; args: string[]; env: NodeJS.ProcessEnv }> = []
+    const run = (command: string, args: string[], options: { env?: NodeJS.ProcessEnv } = {}) => {
+      calls.push({ command, args, env: options.env ?? {} })
+    }
+
+    installAppDependencies(run, { TASK_MARKER: 'kept' }, 'darwin')
+
+    expect(calls.map(({ command, args }) => ({ command, args }))).toEqual([
+      { command: 'install-electron', args: [] },
+      { command: 'electron-builder', args: ['install-app-deps'] },
+    ])
+    expect(calls[0].env).toBe(calls[1].env)
+    expect(calls[0].env).toMatchObject({ TASK_MARKER: 'kept', PYTHON: '/usr/bin/python3' })
   })
 })
 


### PR DESCRIPTION
## Summary

- move focus to the active summary progress control when the final questionnaire answer auto-advances
- expose the active questionnaire progress step with `aria-current="step"`
- strengthen component and hermetic E2E coverage for stepwise backward navigation and retained answers
- re-arm collaboration wait timers that wake before their intended poll instant, preventing extra transcript reads at short deadlines
- report transcript changes found by the final deadline snapshot as completed rather than timed out
- make renderer animation-frame cancellation coverage deterministic with an exact pending-handle assertion
- install Electron synchronously during project postinstall before parallel tests can trigger its lazy downloader

## Root causes

Commit `6f1c637` made option clicks auto-advance, removed the inner summary submit option, and left the questionnaire focus effect targeting answer option buttons only. Clicking the final answer unmounted the focused button, but the summary contained no matching focus destination. Focus fell outside `.extension-questionnaire`, so its bubbled keyboard handler never received Ctrl/Meta+ArrowLeft or PageUp.

Separately, `AgentCollaborationBridge.wait` treated every timer callback as permission to poll. A timer waking just before a 150 ms deadline caused an early transcript read, a second short sleep, and a third read at the deadline.

The renderer cancellation test used the shared zero-delay jsdom animation-frame shim while awaiting React `act()`. The synthetic frame could drain before the test recorded its cancellation baseline, producing a false quality failure.

Finally, Electron 43 exposes an explicit installer but no dependency lifecycle install script. The repository postinstall rebuilt native addons without provisioning the Electron runtime, so parallel Vitest workers could launch Electron's lazy downloader concurrently and collide while extracting `node_modules/electron/dist`.

## Design

The questionnaire focus effect still avoids stealing focus whenever focus remains inside the questionnaire. When a transition removes the focused element, it continues to prefer the active question's first option and now falls back to the active progress control. On the submit summary, that control is the active in-questionnaire navigation target, so the existing keyboard handler works without duplicated shortcuts. The E2E preserves normal wizard semantics: summary → final question → first question.

Collaboration waits now record the intended next poll instant. A helper re-arms early timer callbacks until that instant arrives; only then may the bridge read the transcript. A refreshed deadline snapshot is checked before returning so newly observed output reports `timed_out: false`.

The renderer regression installs a test-scoped animation-frame stub that keeps one exact handle pending. Synchronous reconciliation must cancel that handle before replacing the queued delta with the authoritative transcript. Production scheduling is unchanged.

Project postinstall now resolves Electron's local installer and runs it synchronously through the current Node executable before Electron Builder rebuilds native dependencies. The operation is shell-free, cross-platform, cache-aware, and idempotent. Users who intentionally pass `--ignore-scripts` retain the documented manual recovery flow.

## Impact

Keyboard-only users can review and edit grouped questionnaire answers after reaching the submit summary. Short collaboration waits no longer over-poll transcripts. Renderer concurrency coverage no longer races its own jsdom timer. Clean installs cannot defer Electron extraction into parallel test imports.

## Checks

- questionnaire component tests: 5/5 passed
- relevant questionnaire frontend matrix: 35/35 passed
- exact packaged Electron Prime `ask_user` E2E: 1/1 passed
- collaboration bridge suite, including forced early wake and final-deadline change: 12/12 passed
- renderer concurrency suite: 19/19 passed in five concurrent repetitions
- release-script suite: 69/69 passed
- clean-runtime simulation: Electron `dist` moved aside, postinstall restored it once, and the subsequent coverage suite emitted no lazy downloader message
- full coverage: 126 files / 1,190 tests passed
- `npm run build:bundle` and bundle-size budgets: passed
- `npm run typecheck`: passed on Node 24
- `npm run check`: passed; only existing out-of-scope diagnostics reported
- `git diff --check`: clean

Fixes #38
Fixes #40
Fixes #46
Fixes #47
