### PR TITLE
fix: preserve provider-model catalog integrity under caps

### DIFF
--- a/electron/main/model-catalog-cli.ts
+++ b/electron/main/model-catalog-cli.ts
@@ -1,6 +1,6 @@
 import { supportsFastMode } from 'prime-agent-ai'
 import type { PrimeModelCatalog, PrimeModelDescriptor, PrimeProviderDescriptor } from '../../src/types/api'
-import type { ModelCatalogProvider } from './model-catalog'
+import { catalogLimitWarnings, limitCatalogRelations, type ModelCatalogProvider } from './model-catalog'
 import { withModelVisibility } from './model-visibility'
 import { resolveExecutable, runProcess, type ExecutableSource } from './process-utils'
 import { requireString } from './validation'
@@ -15,8 +15,7 @@ import { requireString } from './validation'
  * CLI reports its version.
  */
 const CATALOG_TTL_MS = 30_000
-const MAX_CATALOG_MODELS = 5_000
-export const MAX_CATALOG_PROVIDERS = 256
+export { MAX_CATALOG_PROVIDERS } from './model-catalog'
 export const DEFAULT_CATALOG_TIMEOUT_MS = 15_000
 export const DEFAULT_CATALOG_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
 const VERSION_MAX_OUTPUT_BYTES = 4_096
@@ -188,7 +187,7 @@ export abstract class CliModelCatalogService implements ModelCatalogProvider {
       this.resolveVersion(executable),
     ])
 
-    const models: PrimeModelDescriptor[] = []
+    const validModels: PrimeModelDescriptor[] = []
     const seenKeys = new Set<string>()
     let invalidEntries = 0
     for (const entry of rawModels) {
@@ -196,41 +195,33 @@ export abstract class CliModelCatalogService implements ModelCatalogProvider {
       if (!model) { invalidEntries += 1; continue }
       if (seenKeys.has(model.key)) continue
       seenKeys.add(model.key)
-      if (models.length < MAX_CATALOG_MODELS) models.push(model)
+      validModels.push(model)
     }
 
-    const providerIds = [...new Set(models.map((model) => model.provider))]
-    const providers = providerIds.map((id): PrimeProviderDescriptor => {
-      const providerModels = models.filter((model) => model.provider === id)
-      return {
-        id,
-        name: id.slice(0, 200),
-        authMethod: 'external',
-        configured: true,
-        authLabel: this.credentialsLabel,
-        modelCount: providerModels.length,
-        availableModelCount: providerModels.filter((model) => model.available).length,
-        enabled: true,
-      }
-    }).sort((a, b) => a.name.localeCompare(b.name)).slice(0, MAX_CATALOG_PROVIDERS)
+    const providerIds = [...new Set(validModels.map((model) => model.provider))]
+    const relation = limitCatalogRelations(validModels, providerIds.map((id): PrimeProviderDescriptor => ({
+      id,
+      name: id.slice(0, 200),
+      authMethod: 'external',
+      configured: true,
+      authLabel: this.credentialsLabel,
+      modelCount: 0,
+      availableModelCount: 0,
+      enabled: true,
+    })))
 
     const warnings = [
-      seenKeys.size > models.length
-        ? `${this.harnessLabel} returned ${seenKeys.size.toLocaleString()} models; GooeyPi loaded the first ${models.length.toLocaleString()}.`
-        : undefined,
-      providerIds.length > providers.length
-        ? `${this.harnessLabel} returned ${providerIds.length.toLocaleString()} providers; GooeyPi loaded the first ${providers.length.toLocaleString()} sorted by name.`
-        : undefined,
+      ...catalogLimitWarnings(this.harnessLabel, relation, { uniqueModels: true }),
       invalidEntries > 0
-        ? `${this.harnessLabel} returned ${invalidEntries.toLocaleString()} model entries GooeyPi could not validate; they were skipped.`
+        ? `${this.harnessLabel} returned ${invalidEntries.toLocaleString('en-US')} model entries GooeyPi could not validate; they were skipped.`
         : undefined,
     ].filter((warning): warning is string => Boolean(warning))
 
     const catalog: PrimeModelCatalog = {
       primeVersion: version,
       refreshedAt: new Date().toISOString(),
-      models,
-      providers,
+      models: relation.models,
+      providers: relation.providers,
       warning: warnings.length ? warnings.join(' ') : undefined,
     }
     if (this.cachedExecutable === executable) {

--- a/electron/main/model-catalog.ts
+++ b/electron/main/model-catalog.ts
@@ -1,4 +1,4 @@
-import type { PrimeModelCatalog } from '../../src/types/api'
+import type { PrimeModelCatalog, PrimeModelDescriptor, PrimeProviderDescriptor } from '../../src/types/api'
 import type { ProviderCatalog } from './agent-rpc'
 import type { PrimeProviderService } from './providers'
 
@@ -17,6 +17,91 @@ import type { PrimeProviderService } from './providers'
  */
 export interface ModelCatalogProvider extends ProviderCatalog {
   catalog(force?: boolean, disabledProviders?: ReadonlySet<string>, disabledModels?: ReadonlySet<string>): Promise<PrimeModelCatalog>
+}
+
+export const MAX_CATALOG_MODELS = 5_000
+export const MAX_CATALOG_PROVIDERS = 256
+
+export interface CatalogLimitResult {
+  models: PrimeModelDescriptor[]
+  providers: PrimeProviderDescriptor[]
+  totalModelCount: number
+  totalProviderCount: number
+  modelsOmittedWithProviders: number
+  modelsOmittedByModelLimit: number
+}
+
+/**
+ * Applies the provider and model limits as one relational operation. Providers
+ * are selected first in a deterministic order, then only models belonging to
+ * those providers are eligible for the model cap. Counts are always rebuilt
+ * from the final model set, so no consumer can observe an orphan model or a
+ * stale provider total.
+ */
+export function limitCatalogRelations(
+  rawModels: ReadonlyArray<PrimeModelDescriptor>,
+  rawProviders: ReadonlyArray<PrimeProviderDescriptor>,
+): CatalogLimitResult {
+  const seenProviderIds = new Set<string>()
+  const uniqueProviders = [...rawProviders]
+    .sort((left, right) => left.name.localeCompare(right.name, 'en-US') || left.id.localeCompare(right.id, 'en-US'))
+    .filter((provider) => {
+      if (seenProviderIds.has(provider.id)) return false
+      seenProviderIds.add(provider.id)
+      return true
+    })
+  const providers = uniqueProviders.slice(0, MAX_CATALOG_PROVIDERS)
+  const retainedProviderIds = new Set(providers.map((provider) => provider.id))
+
+  const seenModelKeys = new Set<string>()
+  const uniqueModels = rawModels.filter((model) => {
+    if (seenModelKeys.has(model.key)) return false
+    seenModelKeys.add(model.key)
+    return true
+  })
+  const modelsForRetainedProviders = uniqueModels.filter((model) => retainedProviderIds.has(model.provider))
+  const models = modelsForRetainedProviders.slice(0, MAX_CATALOG_MODELS)
+  const counts = new Map<string, { total: number; available: number }>()
+  for (const model of models) {
+    const count = counts.get(model.provider) ?? { total: 0, available: 0 }
+    count.total += 1
+    if (model.available) count.available += 1
+    counts.set(model.provider, count)
+  }
+
+  return {
+    models,
+    providers: providers.map((provider) => {
+      const count = counts.get(provider.id)
+      return { ...provider, modelCount: count?.total ?? 0, availableModelCount: count?.available ?? 0 }
+    }),
+    totalModelCount: uniqueModels.length,
+    totalProviderCount: uniqueProviders.length,
+    modelsOmittedWithProviders: uniqueModels.length - modelsForRetainedProviders.length,
+    modelsOmittedByModelLimit: modelsForRetainedProviders.length - models.length,
+  }
+}
+
+/** Produces host-locale-independent warnings describing exactly what survived. */
+export function catalogLimitWarnings(
+  harnessLabel: string,
+  result: CatalogLimitResult,
+  options: { uniqueModels?: boolean } = {},
+): string[] {
+  const count = (value: number): string => value.toLocaleString('en-US')
+  const omittedProviders = result.totalProviderCount - result.providers.length
+  const omittedModels = result.modelsOmittedWithProviders + result.modelsOmittedByModelLimit
+  const representedProviders = new Set(result.models.map((model) => model.provider)).size
+  const warnings: string[] = []
+  if (omittedProviders > 0) {
+    warnings.push(`${harnessLabel} returned ${count(result.totalProviderCount)} valid providers; GooeyPi retained ${count(result.providers.length)} sorted by name (${count(omittedProviders)} omitted by the provider limit).`)
+  }
+  if (omittedModels > 0) {
+    const modelKind = options.uniqueModels ? 'valid unique models' : 'valid models'
+    const representedLabel = representedProviders === 1 ? 'provider' : 'providers'
+    warnings.push(`${harnessLabel} returned ${count(result.totalModelCount)} ${modelKind}; GooeyPi retained ${count(result.models.length)} across ${count(representedProviders)} ${representedLabel} (${count(omittedModels)} omitted by catalog limits: ${count(result.modelsOmittedWithProviders)} with omitted providers and ${count(result.modelsOmittedByModelLimit)} beyond the model limit).`)
+  }
+  return warnings
 }
 
 /**

--- a/electron/main/providers.ts
+++ b/electron/main/providers.ts
@@ -8,12 +8,12 @@ import type { Api, Model } from 'prime-agent-ai'
 import type { OAuthLoginCallbacks } from 'prime-agent-ai/oauth'
 import type { PrimeModelCatalog, PrimeModelDescriptor, PrimeProviderDescriptor, ProviderAuthEvent, ProviderAuthMethod, ProviderAuthSource, SkillRecord } from '../../src/types/api'
 import { errorCode, readAtMost } from './plugins/file-io'
+import { catalogLimitWarnings, limitCatalogRelations } from './model-catalog'
 import { withModelVisibility } from './model-visibility'
 import { isRecord, requireString, requireWebUrl } from './validation'
 
 const CATALOG_TTL_MS = 30_000
-const MAX_CATALOG_MODELS = 5_000
-export const MAX_CATALOG_PROVIDERS = 256
+export { MAX_CATALOG_PROVIDERS } from './model-catalog'
 const EXTERNAL_AUTH_PROVIDERS = new Set(['amazon-bedrock', 'google-vertex'])
 const OAUTH_TIMEOUT_MS = 10 * 60_000
 const MAX_MCP_SETTINGS_BYTES = 4 * 1024 * 1024
@@ -218,11 +218,9 @@ export class PrimeProviderService {
     const authStatuses = new Map([...providerIds].map((id) => [id, this.registry.getProviderAuthStatus(id)]))
     const configuredProviders = new Set([...authStatuses].filter(([, status]) => status.configured).map(([id]) => id))
     const { keys: available, fallbackProviders } = resolveAvailableModelKeys(eligibleModels, executableModels, configuredProviders)
-    const models = eligibleModels.slice(0, MAX_CATALOG_MODELS).map((model) => toModelDescriptor(model, available))
     const validProviderIds = [...providerIds].filter(safeProviderId)
-    const providers = validProviderIds.map((id): PrimeProviderDescriptor => {
+    const relation = limitCatalogRelations(eligibleModels.map((model) => toModelDescriptor(model, available)), validProviderIds.map((id): PrimeProviderDescriptor => {
       const authStatus = authStatuses.get(id) ?? this.registry.getProviderAuthStatus(id)
-      const providerModels = models.filter((model) => model.provider === id)
       const authMethod: ProviderAuthMethod = oauthProviders.has(id) ? 'oauth' : EXTERNAL_AUTH_PROVIDERS.has(id) ? 'external' : 'api_key'
       return {
         id,
@@ -231,20 +229,18 @@ export class PrimeProviderService {
         configured: authStatus.configured,
         authSource: authStatus.source as ProviderAuthSource | undefined,
         authLabel: authStatus.label?.slice(0, 200),
-        modelCount: providerModels.length,
-        availableModelCount: providerModels.filter((model) => model.available).length,
+        modelCount: 0,
+        availableModelCount: 0,
         enabled: true,
       }
-    }).sort((a, b) => a.name.localeCompare(b.name)).slice(0, MAX_CATALOG_PROVIDERS)
+    }))
 
     const warnings = [
-      snapshot.models.length > models.length
-        ? `Prime Agent returned ${snapshot.models.length.toLocaleString()} models; GooeyPi loaded the first ${models.length.toLocaleString()} valid entries.`
+      ...catalogLimitWarnings('Prime Agent', relation, { uniqueModels: true }),
+      snapshot.models.length > eligibleModels.length
+        ? `Prime Agent returned ${(snapshot.models.length - eligibleModels.length).toLocaleString('en-US')} model entries GooeyPi could not validate; they were skipped.`
         : undefined,
-      validProviderIds.length > providers.length
-        ? `Prime Agent returned ${validProviderIds.length.toLocaleString()} providers; GooeyPi loaded the first ${providers.length.toLocaleString()} sorted by name.`
-        : undefined,
-      fallbackProviders.includes('openai-codex')
+      fallbackProviders.includes('openai-codex') && relation.models.some((model) => model.provider === 'openai-codex')
         ? 'ChatGPT subscription model discovery was unavailable or incomplete; GooeyPi is showing Prime Agent’s configured Codex catalogue.'
         : undefined,
       executableDiscoveryWarning,
@@ -254,8 +250,8 @@ export class PrimeProviderService {
     this.cachedCatalog = {
       primeVersion: VERSION,
       refreshedAt: new Date().toISOString(),
-      models,
-      providers,
+      models: relation.models,
+      providers: relation.providers,
       warning: warnings.length ? warnings.join(' ') : undefined,
     }
     this.cachedAt = Date.now()

--- a/tests/backend/omp-agent-rpc.test.ts
+++ b/tests/backend/omp-agent-rpc.test.ts
@@ -11,6 +11,8 @@ import {
   type RpcChunkAssemblyTiming,
 } from '../../electron/main/agent-rpc/runtime'
 import { RPC_READ_FRAME_LIMIT_BYTES } from '../../electron/main/jsonl-limits'
+import { OmpModelCatalogService, MAX_CATALOG_PROVIDERS } from '../../electron/main/providers-omp'
+import { ScheduledRunExecutor } from '../../electron/main/schedules/executor'
 import type { PrimeModelDescriptor } from '../../src/types/api'
 import { waitUntil } from '../helpers/wait'
 
@@ -32,6 +34,8 @@ interface FakeOmpOptions {
   /** When false the fake rejects negotiate_protocol like an unsupported version. */
   acceptNegotiate?: boolean
   sessionActions?: Record<string, unknown>
+  /** Optional model payload served when the same fake is probed as an OMP catalog CLI. */
+  catalogModels?: unknown[]
 }
 
 function fakeOmpAgent(options: FakeOmpOptions = {}): { cwd: string; executable: string } {
@@ -39,6 +43,8 @@ function fakeOmpAgent(options: FakeOmpOptions = {}): { cwd: string; executable: 
   dirs.push(cwd)
   const executable = join(cwd, 'fake-omp.cjs')
   writeFileSync(executable, `#!/usr/bin/env node
+if (process.argv[2] === '--version') { process.stdout.write('omp/1.2.3\\n'); process.exit(0) }
+if (process.argv[2] === 'models' && process.argv[3] === '--json') { process.stdout.write(${JSON.stringify(JSON.stringify({ models: options.catalogModels ?? [] }))}); process.exit(0) }
 const readline = require('node:readline')
 const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n')
 const sessionActions = ${JSON.stringify(options.sessionActions)}
@@ -335,6 +341,38 @@ describe('OMP RPC handshake', () => {
     await waitUntil(() => events.some((event) => event.type === 'fake_argv'))
     const argv = (events.find((event) => event.type === 'fake_argv') as { argv: string[] }).argv
     expect(argv).not.toContain('--approval-mode')
+  })
+
+  it('uses the real capped catalog for scheduled validation, launch, and set_model', async () => {
+    const models = Array.from({ length: MAX_CATALOG_PROVIDERS + 1 }, (_, index) => ({
+      provider: `provider-${String(index).padStart(3, '0')}`,
+      id: 'model',
+      name: `Provider ${index} model`,
+      reasoning: false,
+      thinking: null,
+      input: ['text'],
+      contextWindow: 1,
+      maxTokens: 1,
+    }))
+    const fake = fakeOmpAgent({ catalogModels: models })
+    const catalog = new OmpModelCatalogService(fake.executable)
+    const manager = ompManager(fake.executable, { providers: catalog })
+    const schedules = new ScheduledRunExecutor({} as never, {} as never, manager, catalog, () => new Set(), () => new Set())
+    const retainedExecution = { model: 'provider-000/model', thinking: 'off', speed: 'normal' } as const
+    const omittedExecution = { model: 'provider-256/model', thinking: 'off', speed: 'normal' } as const
+
+    await expect(schedules.validateExecution(retainedExecution)).resolves.toBeUndefined()
+    await expect(schedules.validateExecution(omittedExecution)).rejects.toThrow(/not found in the OMP catalog/)
+    await expect(manager.start({ cwd: fake.cwd, model: omittedExecution.model })).rejects.toThrow(/not found in the OMP catalog/)
+    expect(manager.list()).toEqual([])
+
+    const events: Array<Record<string, unknown>> = []
+    manager.setEventSink(({ event }) => events.push(event))
+    const runtime = await manager.start({ cwd: fake.cwd, model: retainedExecution.model })
+    await waitUntil(() => events.some((event) => event.type === 'fake_argv'))
+    const argv = (events.find((event) => event.type === 'fake_argv') as { argv: string[] }).argv
+    expect(argv[argv.indexOf('--model') + 1]).toBe(retainedExecution.model)
+    await expect(manager.command(runtime.runtimeId, { type: 'set_model', provider: 'provider-256', modelId: 'model' })).rejects.toThrow(/not found in the OMP catalog/)
   })
 })
 

--- a/tests/backend/omp-ipc.test.ts
+++ b/tests/backend/omp-ipc.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 const electronMocks = vi.hoisted(() => ({
   app: {},
@@ -14,11 +17,36 @@ const electronMocks = vi.hoisted(() => ({
 vi.mock('electron', () => electronMocks)
 
 import { registerIpc, type IpcRegistration } from '../../electron/main/ipc'
+import { OmpModelCatalogService, MAX_CATALOG_PROVIDERS } from '../../electron/main/providers-omp'
 
 const EXPECTED_URL = 'prime-work://app/'
 const PRIME_SESSION = '/home/user/.prime/agent/sessions/session.jsonl'
 const OMP_SESSION = '/home/user/.omp/agent/sessions/bucket/session.jsonl'
 const PI_SESSION = '/home/user/.pi/agent/sessions/--home-user-project--/session.jsonl'
+const fixtureDirs: string[] = []
+
+function fakeOverflowCatalog(): OmpModelCatalogService {
+  const directory = mkdtempSync(join(tmpdir(), 'gooeypi-omp-ipc-catalog-'))
+  fixtureDirs.push(directory)
+  const executable = join(directory, 'omp.cjs')
+  const models = Array.from({ length: MAX_CATALOG_PROVIDERS + 1 }, (_, index) => ({
+    provider: `provider-${String(index).padStart(3, '0')}`,
+    id: 'model',
+    name: `Provider ${index} model`,
+    reasoning: false,
+    thinking: null,
+    input: ['text'],
+    contextWindow: 1,
+    maxTokens: 1,
+  }))
+  writeFileSync(executable, `#!/usr/bin/env node
+if (process.argv[2] === '--version') { process.stdout.write('omp/1.2.3\\n'); process.exit(0) }
+if (process.argv[2] === 'models' && process.argv[3] === '--json') { process.stdout.write(${JSON.stringify(JSON.stringify({ models }))}); process.exit(0) }
+process.exit(2)
+`)
+  chmodSync(executable, 0o755)
+  return new OmpModelCatalogService(executable)
+}
 
 function serviceStub(): Record<string, unknown> {
   return new Proxy({}, { get: () => vi.fn(async () => undefined) })
@@ -167,7 +195,10 @@ describe('harness-aware IPC routing', () => {
     }
   })
 
-  afterEach(() => { harness.registration.dispose() })
+  afterEach(() => {
+    harness.registration.dispose()
+    for (const directory of fixtureDirs.splice(0)) rmSync(directory, { recursive: true, force: true })
+  })
 
   it('exposes harness refresh through the fixed authorized app channel', async () => {
     await expect(harness.invoke('app:refresh-harnesses')).resolves.toMatchObject({ meta: { version: '0.0.0-refreshed' } })
@@ -359,6 +390,27 @@ describe('harness-aware IPC routing', () => {
       ],
     })
     expect(harness.services.settings.update).toHaveBeenLastCalledWith({ ompDisabledProviders: ['anthropic'], ompDisabledModels: [] })
+  })
+
+  it('applies provider and model toggles only to models retained by a real overflow catalog', async () => {
+    const overflowCatalog = fakeOverflowCatalog()
+    const catalogService = harness.services.omp.catalog as unknown as { catalog: OmpModelCatalogService['catalog'] }
+    catalogService.catalog = overflowCatalog.catalog.bind(overflowCatalog)
+
+    const initial = await harness.invoke('providers:catalog', true, 'omp') as Awaited<ReturnType<OmpModelCatalogService['catalog']>>
+    expect(initial.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(initial.models).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(initial.models.some((model) => model.key === 'provider-256/model')).toBe(false)
+
+    const disabled = await harness.invoke('providers:set-enabled', 'provider-000', false, 'omp') as Awaited<ReturnType<OmpModelCatalogService['catalog']>>
+    expect(disabled.providers.find((provider) => provider.id === 'provider-000')?.enabled).toBe(false)
+    expect(disabled.models.find((model) => model.key === 'provider-000/model')?.enabled).toBe(false)
+
+    const reenabled = await harness.invoke('providers:set-model-enabled', 'provider-000/model', true, 'omp') as Awaited<ReturnType<OmpModelCatalogService['catalog']>>
+    expect(reenabled.providers.find((provider) => provider.id === 'provider-000')?.enabled).toBe(true)
+    expect(reenabled.models.find((model) => model.key === 'provider-000/model')?.enabled).toBe(true)
+    await expect(async () => harness.invoke('providers:set-enabled', 'provider-256', false, 'omp')).rejects.toThrow('Provider was not found')
+    await expect(async () => harness.invoke('providers:set-model-enabled', 'provider-256/model', false, 'omp')).rejects.toThrow('Model was not found')
   })
 
   it('rejects provider credential mutations aimed at the omp harness', async () => {

--- a/tests/backend/providers-omp.test.ts
+++ b/tests/backend/providers-omp.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { ModelCatalogProvider } from '../../electron/main/model-catalog'
 import { OMP_NOT_INSTALLED_WARNING, OmpModelCatalogService, MAX_CATALOG_PROVIDERS } from '../../electron/main/providers-omp'
+import type { PrimeModelCatalog } from '../../src/types/api'
 import { waitUntil } from '../helpers/wait'
 
 const dirs: string[] = []
@@ -41,6 +42,22 @@ const sampleCatalog = {
 
 const processExists = (pid: number): boolean => {
   try { process.kill(pid, 0); return true } catch { return false }
+}
+
+function expectRelationalIntegrity(catalog: PrimeModelCatalog): void {
+  const providerIds = catalog.providers.map((provider) => provider.id)
+  expect(new Set(providerIds).size).toBe(providerIds.length)
+  const providerIdSet = new Set(providerIds)
+  for (const model of catalog.models) expect(providerIdSet.has(model.provider)).toBe(true)
+  for (const provider of catalog.providers) {
+    const models = catalog.models.filter((model) => model.provider === provider.id)
+    expect(provider.modelCount).toBe(models.length)
+    expect(provider.availableModelCount).toBe(models.filter((model) => model.available).length)
+  }
+}
+
+function ompModel(provider: string, id: string): Record<string, unknown> {
+  return { provider, id, name: `${provider} ${id}`, reasoning: false, thinking: null, input: ['text'], contextWindow: 1, maxTokens: 1 }
 }
 
 describe('OMP model catalog service', () => {
@@ -92,6 +109,9 @@ describe('OMP model catalog service', () => {
     expect(anthropic.modelCount).toBe(2)
     expect(anthropic.availableModelCount).toBe(2)
     expect(anthropic.enabled).toBe(true)
+    const cached = await service.catalog()
+    expect(cached.models).toEqual(catalog.models)
+    expect(cached.providers).toEqual(catalog.providers)
   })
 
   it('resolves availability, capabilities, and desktop provider enablement', async () => {
@@ -188,23 +208,37 @@ setTimeout(() => { process.stdout.write(${JSON.stringify(JSON.stringify(sampleCa
     expect(runs()).toBe(2)
   })
 
-  it('serves the last good catalog with a warning when a refresh fails', async () => {
+  it('keeps omitted models absent from cached and stale overflow catalogs', async () => {
     const stateFile = join(tempDir(), 'mode')
+    const overflowModels = Array.from({ length: MAX_CATALOG_PROVIDERS + 1 }, (_, index) => (
+      ompModel(`provider-${String(index).padStart(3, '0')}`, 'model')
+    ))
     // First run succeeds; every later run exits non-zero.
     const executable = fakeOmp(`
 const fs = require('node:fs')
 if (fs.existsSync(${JSON.stringify(stateFile)})) process.exit(7)
 fs.writeFileSync(${JSON.stringify(stateFile)}, 'ran')
-process.stdout.write(${JSON.stringify(JSON.stringify(sampleCatalog))})
+process.stdout.write(${JSON.stringify(JSON.stringify({ models: overflowModels }))})
 `)
     const service = new OmpModelCatalogService(executable)
     const fresh = await service.catalog(true)
-    expect(fresh.warning).toBeUndefined()
+    expect(fresh.models).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(fresh.models.some((model) => model.key === 'provider-256/model')).toBe(false)
+    expect(fresh.warning).toMatch(/provider limit/)
+
+    const cached = await service.catalog()
+    expect(cached.models).toEqual(fresh.models)
+    expect(cached.providers).toEqual(fresh.providers)
+    expect(cached.models.some((model) => model.key === 'provider-256/model')).toBe(false)
 
     const stale = await service.catalog(true)
-    expect(stale.models.length).toBe(fresh.models.length)
+    expect(stale.models).toEqual(fresh.models)
+    expect(stale.providers).toEqual(fresh.providers)
+    expect(stale.models.some((model) => model.key === 'provider-256/model')).toBe(false)
     expect(stale.warning).toMatch(/could not be refreshed/)
     expect(stale.warning).toMatch(/last loaded catalog/)
+    expect(await service.capabilities('provider-256', 'model')).toBeUndefined()
+    await expect(service.requireAvailableModel('provider-256/model')).rejects.toThrow(/not found/)
 
     // With no prior catalog the failure still surfaces.
     const failingOnly = new OmpModelCatalogService(fakeOmp('process.exit(7)'))
@@ -250,15 +284,63 @@ process.stdout.write(${JSON.stringify(JSON.stringify(sampleCatalog))})
     expect(catalog.providers.map((provider) => provider.id)).toEqual(['anthropic', 'zai'])
   })
 
-  it('caps runaway catalogs at the model and provider limits', async () => {
+  it('keeps an exact-boundary catalog unchanged and relationally consistent', async () => {
     const models: unknown[] = []
-    // Provider overflow entries come first so they land inside the 5,000-model
-    // cap and exercise the 256-provider cap independently.
+    for (let index = 0; index < MAX_CATALOG_PROVIDERS; index += 1) {
+      models.push(ompModel(`provider-${String(index).padStart(3, '0')}`, 'model'))
+    }
+    for (let index = MAX_CATALOG_PROVIDERS; index < 5_000; index += 1) {
+      models.push(ompModel('provider-000', `model-${index}`))
+    }
+
+    const service = new OmpModelCatalogService(fakeOmpWithCatalog({ models }))
+    const catalog = await service.catalog(true)
+
+    expect(catalog.models).toHaveLength(5_000)
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.warning).toBeUndefined()
+    expectRelationalIntegrity(catalog)
+  })
+
+  it('caps provider-only overflow without returning orphan models', async () => {
+    const models = Array.from({ length: MAX_CATALOG_PROVIDERS + 1 }, (_, index) => (
+      ompModel(`provider-${String(index).padStart(3, '0')}`, 'model')
+    ))
+    const service = new OmpModelCatalogService(fakeOmpWithCatalog({ models }))
+    const catalog = await service.catalog(true)
+
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.models).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.warning).toMatch(/257 valid providers.*retained 256.*1 omitted/)
+    expect(catalog.warning).toMatch(/257 valid unique models.*retained 256.*1 omitted/)
+    expect(catalog.warning).toContain('1 omitted by catalog limits: 1 with omitted providers and 0 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    await expect(service.requireAvailableModel('provider-256/model')).rejects.toThrow(/not found/)
+    expect(await service.capabilities('provider-256', 'model')).toBeUndefined()
+  })
+
+  it('caps model-only overflow while keeping visibility and launch validation aligned', async () => {
+    const models = Array.from({ length: 5_001 }, (_, index) => ompModel('provider-000', `model-${index}`))
+    const service = new OmpModelCatalogService(fakeOmpWithCatalog({ models }))
+    const catalog = await service.catalog(true, new Set(), new Set(['provider-000/model-0']))
+
+    expect(catalog.providers).toHaveLength(1)
+    expect(catalog.models).toHaveLength(5_000)
+    expect(catalog.models[0]?.enabled).toBe(false)
+    expect(catalog.warning).toMatch(/5,001 valid unique models.*retained 5,000.*1 omitted/)
+    expect(catalog.warning).toContain('1 omitted by catalog limits: 0 with omitted providers and 1 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    await expect(service.requireAvailableModel('provider-000/model-5000')).rejects.toThrow(/not found/)
+    await expect(service.requireAvailableModel('provider-000/model-0', new Set(), new Set(['provider-000/model-0']))).rejects.toThrow(/disabled/)
+  })
+
+  it('applies simultaneous model and provider caps as one relational operation', async () => {
+    const models: unknown[] = []
     for (let index = 0; index < 300; index += 1) {
-      models.push({ provider: `overflow-${String(index).padStart(3, '0')}`, id: 'model', name: `Overflow ${index}`, reasoning: false, thinking: null, input: ['text'], contextWindow: 1, maxTokens: 1 })
+      models.push(ompModel(`overflow-${String(index).padStart(3, '0')}`, 'model'))
     }
     for (let index = 0; index < 5_010; index += 1) {
-      models.push({ provider: 'anthropic', id: `model-${index}`, name: `Model ${index}`, reasoning: false, thinking: null, input: ['text'], contextWindow: 1, maxTokens: 1 })
+      models.push(ompModel('anthropic', `model-${index}`))
     }
     const service = new OmpModelCatalogService(fakeOmpWithCatalog({ models }))
     const catalog = await service.catalog(true)
@@ -267,7 +349,12 @@ process.stdout.write(${JSON.stringify(JSON.stringify(sampleCatalog))})
     expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
     const names = catalog.providers.map((provider) => provider.name)
     expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)))
-    expect(catalog.warning).toMatch(/models/)
+    expect(catalog.warning).toMatch(/301 valid providers.*retained 256.*45 omitted/)
+    expect(catalog.warning).toMatch(/5,310 valid unique models.*retained 5,000.*310 omitted/)
+    expect(catalog.warning).toContain('310 omitted by catalog limits: 45 with omitted providers and 265 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    expect(catalog.models.some((model) => model.provider === 'overflow-299')).toBe(false)
+    await expect(service.requireAvailableModel('overflow-299/model')).rejects.toThrow(/not found/)
   })
 
   it('rejects a CLI that exits with a failure status', async () => {

--- a/tests/backend/providers-pi.test.ts
+++ b/tests/backend/providers-pi.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { ModelCatalogProvider } from '../../electron/main/model-catalog'
 import { PI_NOT_INSTALLED_WARNING, PiModelCatalogService, MAX_CATALOG_PROVIDERS } from '../../electron/main/providers-pi'
+import type { PrimeModelCatalog } from '../../src/types/api'
 import { waitUntil } from '../helpers/wait'
 
 const dirs: string[] = []
@@ -68,6 +69,22 @@ const processExists = (pid: number): boolean => {
   try { process.kill(pid, 0); return true } catch { return false }
 }
 
+function expectRelationalIntegrity(catalog: PrimeModelCatalog): void {
+  const providerIds = catalog.providers.map((provider) => provider.id)
+  expect(new Set(providerIds).size).toBe(providerIds.length)
+  const providerIdSet = new Set(providerIds)
+  for (const model of catalog.models) expect(providerIdSet.has(model.provider)).toBe(true)
+  for (const provider of catalog.providers) {
+    const models = catalog.models.filter((model) => model.provider === provider.id)
+    expect(provider.modelCount).toBe(models.length)
+    expect(provider.availableModelCount).toBe(models.filter((model) => model.available).length)
+  }
+}
+
+function piModel(provider: string, id: string): Record<string, unknown> {
+  return { provider, id, name: `${provider} ${id}`, reasoning: false, input: ['text'], contextWindow: 1, maxTokens: 1 }
+}
+
 describe('Pi model catalog service', () => {
   it('invalidates the unavailable cache when discovery finds an executable', async () => {
     let executable: string | null = null
@@ -123,6 +140,9 @@ describe('Pi model catalog service', () => {
     expect(google.modelCount).toBe(3)
     expect(google.availableModelCount).toBe(3)
     expect(google.enabled).toBe(true)
+    const cached = await service.catalog()
+    expect(cached.models).toEqual(catalog.models)
+    expect(cached.providers).toEqual(catalog.providers)
   })
 
   it('resolves availability, capabilities, and desktop provider enablement', async () => {
@@ -331,15 +351,63 @@ process.stdout.write(JSON.stringify({ type: 'response', id: '1', command: 'get_a
     expect(catalog.providers.map((provider) => provider.id)).toEqual(['openai-codex', 'zai'])
   })
 
-  it('caps runaway catalogs at the model and provider limits', async () => {
+  it('keeps an exact-boundary catalog unchanged and relationally consistent', async () => {
     const models: unknown[] = []
-    // Provider overflow entries come first so they land inside the 5,000-model
-    // cap and exercise the 256-provider cap independently.
+    for (let index = 0; index < MAX_CATALOG_PROVIDERS; index += 1) {
+      models.push(piModel(`provider-${String(index).padStart(3, '0')}`, 'model'))
+    }
+    for (let index = MAX_CATALOG_PROVIDERS; index < 5_000; index += 1) {
+      models.push(piModel('provider-000', `model-${index}`))
+    }
+
+    const service = new PiModelCatalogService(fakePiWithCatalog({ models }))
+    const catalog = await service.catalog(true)
+
+    expect(catalog.models).toHaveLength(5_000)
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.warning).toBeUndefined()
+    expectRelationalIntegrity(catalog)
+  })
+
+  it('caps provider-only overflow without returning orphan models', async () => {
+    const models = Array.from({ length: MAX_CATALOG_PROVIDERS + 1 }, (_, index) => (
+      piModel(`provider-${String(index).padStart(3, '0')}`, 'model')
+    ))
+    const service = new PiModelCatalogService(fakePiWithCatalog({ models }))
+    const catalog = await service.catalog(true)
+
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.models).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.warning).toMatch(/257 valid providers.*retained 256.*1 omitted/)
+    expect(catalog.warning).toMatch(/257 valid unique models.*retained 256.*1 omitted/)
+    expect(catalog.warning).toContain('1 omitted by catalog limits: 1 with omitted providers and 0 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    await expect(service.requireAvailableModel('provider-256/model')).rejects.toThrow(/not found/)
+    expect(await service.capabilities('provider-256', 'model')).toBeUndefined()
+  })
+
+  it('caps model-only overflow while keeping visibility and launch validation aligned', async () => {
+    const models = Array.from({ length: 5_001 }, (_, index) => piModel('provider-000', `model-${index}`))
+    const service = new PiModelCatalogService(fakePiWithCatalog({ models }))
+    const catalog = await service.catalog(true, new Set(), new Set(['provider-000/model-0']))
+
+    expect(catalog.providers).toHaveLength(1)
+    expect(catalog.models).toHaveLength(5_000)
+    expect(catalog.models[0]?.enabled).toBe(false)
+    expect(catalog.warning).toMatch(/5,001 valid unique models.*retained 5,000.*1 omitted/)
+    expect(catalog.warning).toContain('1 omitted by catalog limits: 0 with omitted providers and 1 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    await expect(service.requireAvailableModel('provider-000/model-5000')).rejects.toThrow(/not found/)
+    await expect(service.requireAvailableModel('provider-000/model-0', new Set(), new Set(['provider-000/model-0']))).rejects.toThrow(/disabled/)
+  })
+
+  it('applies simultaneous model and provider caps as one relational operation', async () => {
+    const models: unknown[] = []
     for (let index = 0; index < 300; index += 1) {
-      models.push({ provider: `overflow-${String(index).padStart(3, '0')}`, id: 'model', name: `Overflow ${index}`, reasoning: false, input: ['text'], contextWindow: 1, maxTokens: 1 })
+      models.push(piModel(`overflow-${String(index).padStart(3, '0')}`, 'model'))
     }
     for (let index = 0; index < 5_010; index += 1) {
-      models.push({ provider: 'google', id: `model-${index}`, name: `Model ${index}`, reasoning: false, input: ['text'], contextWindow: 1, maxTokens: 1 })
+      models.push(piModel('google', `model-${index}`))
     }
     const service = new PiModelCatalogService(fakePiWithCatalog({ models }))
     const catalog = await service.catalog(true)
@@ -348,6 +416,11 @@ process.stdout.write(JSON.stringify({ type: 'response', id: '1', command: 'get_a
     expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
     const names = catalog.providers.map((provider) => provider.name)
     expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)))
-    expect(catalog.warning).toMatch(/models/)
+    expect(catalog.warning).toMatch(/301 valid providers.*retained 256.*45 omitted/)
+    expect(catalog.warning).toMatch(/5,310 valid unique models.*retained 5,000.*310 omitted/)
+    expect(catalog.warning).toContain('310 omitted by catalog limits: 45 with omitted providers and 265 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    expect(catalog.models.some((model) => model.provider === 'overflow-299')).toBe(false)
+    await expect(service.requireAvailableModel('overflow-299/model')).rejects.toThrow(/not found/)
   })
 })

--- a/tests/backend/providers.test.ts
+++ b/tests/backend/providers.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MAX_CATALOG_PROVIDERS, PrimeProviderService, resolveAvailableModelKeys, resolveMcpOAuthDiscovery } from '../../electron/main/providers'
+import type { PrimeModelCatalog } from '../../src/types/api'
 
 const dirs: string[] = []
 afterEach(() => {
@@ -29,6 +30,54 @@ function serviceWithModels(config: unknown): PrimeProviderService {
   const modelsPath = join(dir, 'models.json')
   writeFileSync(modelsPath, JSON.stringify(config))
   return new PrimeProviderService({ authPath: join(dir, 'auth.json'), modelsPath })
+}
+
+function primeModel(provider: string, id: string): Record<string, unknown> {
+  return {
+    provider,
+    id,
+    name: `${provider} ${id}`,
+    api: 'openai-completions',
+    baseUrl: 'http://127.0.0.1:8118/v1',
+    reasoning: false,
+    input: ['text'],
+    contextWindow: 1,
+    maxTokens: 1,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  }
+}
+
+function serviceWithRegistryModels(models: unknown[], options: { executableModels?: unknown[] } = {}): PrimeProviderService {
+  const providerService = service()
+  const internals = providerService as unknown as {
+    authStorage: { getOAuthProviders(): Array<{ id: string; name: string }> }
+    registry: {
+      refreshModelCatalog(): Promise<{ models: unknown[] }>
+      getExecutableModels(): Promise<unknown[]>
+      getProviderAuthStatus(id: string): { configured: boolean; source: string; label: string }
+      getProviderDisplayName(id: string): string
+      getError(): string | undefined
+    }
+  }
+  internals.authStorage.getOAuthProviders = () => []
+  internals.registry.refreshModelCatalog = async () => ({ models })
+  internals.registry.getExecutableModels = async () => options.executableModels ?? models
+  internals.registry.getProviderAuthStatus = () => ({ configured: true, source: 'stored', label: 'Test credentials' })
+  internals.registry.getProviderDisplayName = (id) => id
+  internals.registry.getError = () => undefined
+  return providerService
+}
+
+function expectRelationalIntegrity(catalog: PrimeModelCatalog): void {
+  const providerIds = catalog.providers.map((provider) => provider.id)
+  expect(new Set(providerIds).size).toBe(providerIds.length)
+  const providerIdSet = new Set(providerIds)
+  for (const model of catalog.models) expect(providerIdSet.has(model.provider)).toBe(true)
+  for (const provider of catalog.providers) {
+    const models = catalog.models.filter((model) => model.provider === provider.id)
+    expect(provider.modelCount).toBe(models.length)
+    expect(provider.availableModelCount).toBe(models.filter((model) => model.available).length)
+  }
 }
 
 describe('Prime provider adapter', () => {
@@ -107,7 +156,8 @@ describe('Prime provider adapter', () => {
   })
 
   it('returns the Prime catalog with model-specific capability metadata', async () => {
-    const catalog = await service().catalog(true)
+    const providerService = service()
+    const catalog = await providerService.catalog(true)
     const gpt54 = catalog.models.find((model) => model.provider === 'openai-codex' && model.id === 'gpt-5.4')
     const gpt56 = catalog.models.find((model) => model.provider === 'openai-codex' && model.id === 'gpt-5.6-sol')
 
@@ -117,6 +167,13 @@ describe('Prime provider adapter', () => {
     expect(gpt54?.availableThinkingLevels).not.toContain('max')
     expect(gpt56?.availableThinkingLevels).toContain('max')
     expect(gpt56?.availableThinkingLevels).not.toContain('minimal')
+    expectRelationalIntegrity(catalog)
+    const providerNames = catalog.providers.map((provider) => provider.name)
+    expect(providerNames).toEqual([...providerNames].sort((left, right) => left.localeCompare(right, 'en-US')))
+    expect(new Set(catalog.models.map((model) => model.key)).size).toBe(catalog.models.length)
+    const cached = await providerService.catalog()
+    expect(cached.models).toEqual(catalog.models)
+    expect(cached.providers).toEqual(catalog.providers)
   })
 
   it('single-flights concurrent catalog refreshes and clears the in-flight promise', async () => {
@@ -178,27 +235,112 @@ describe('Prime provider adapter', () => {
     expect(deepseek?.availableThinkingLevels).toEqual(['off', 'high', 'xhigh'])
   })
 
-  it('sorts providers before capping the catalog and warns about the overflow', async () => {
-    const customProviders: Record<string, unknown> = {}
+  it('keeps an exact-boundary catalog unchanged and relationally consistent', async () => {
+    const models: unknown[] = []
+    for (let index = 0; index < MAX_CATALOG_PROVIDERS; index += 1) {
+      models.push(primeModel(`provider-${String(index).padStart(3, '0')}`, 'model'))
+    }
+    for (let index = MAX_CATALOG_PROVIDERS; index < 5_000; index += 1) {
+      models.push(primeModel('provider-000', `model-${index}`))
+    }
+
+    const catalog = await serviceWithRegistryModels(models).catalog(true)
+
+    expect(catalog.models).toHaveLength(5_000)
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.warning).toBeUndefined()
+    expectRelationalIntegrity(catalog)
+  })
+
+  it('caps provider-only overflow without returning orphan models', async () => {
+    const models = Array.from({ length: MAX_CATALOG_PROVIDERS + 1 }, (_, index) => (
+      primeModel(`provider-${String(index).padStart(3, '0')}`, 'model')
+    ))
+    const providerService = serviceWithRegistryModels(models)
+    const catalog = await providerService.catalog(true)
+
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.models).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.warning).toMatch(/257 valid providers.*retained 256.*1 omitted/)
+    expect(catalog.warning).toMatch(/257 valid unique models.*retained 256.*1 omitted/)
+    expect(catalog.warning).toContain('1 omitted by catalog limits: 1 with omitted providers and 0 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    await expect(providerService.requireAvailableModel('provider-256/model')).rejects.toThrow(/not found/)
+    expect(await providerService.capabilities('provider-256', 'model')).toBeUndefined()
+  })
+
+  it('caps model-only overflow while keeping visibility and launch validation aligned', async () => {
+    const models = Array.from({ length: 5_001 }, (_, index) => primeModel('provider-000', `model-${index}`))
+    const providerService = serviceWithRegistryModels(models)
+    const catalog = await providerService.catalog(true, new Set(), new Set(['provider-000/model-0']))
+
+    expect(catalog.providers).toHaveLength(1)
+    expect(catalog.models).toHaveLength(5_000)
+    expect(catalog.models[0]?.enabled).toBe(false)
+    expect(catalog.warning).toMatch(/5,001 valid unique models.*retained 5,000.*1 omitted/)
+    expect(catalog.warning).toContain('1 omitted by catalog limits: 0 with omitted providers and 1 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    await expect(providerService.requireAvailableModel('provider-000/model-5000')).rejects.toThrow(/not found/)
+    await expect(providerService.requireAvailableModel('provider-000/model-0', new Set(), new Set(['provider-000/model-0']))).rejects.toThrow(/disabled/)
+  })
+
+  it('applies simultaneous model and provider caps as one relational operation', async () => {
+    const models: unknown[] = []
     for (let index = 0; index < 300; index += 1) {
-      customProviders[`zz-overflow-${String(index).padStart(3, '0')}`] = {
-        baseUrl: 'http://127.0.0.1:8118/v1', api: 'openai-completions', apiKey: 'prime-local',
-        models: [{ id: `model-${index}` }],
-      }
+      models.push(primeModel(`overflow-${String(index).padStart(3, '0')}`, 'model'))
     }
-    customProviders['aa-first-provider'] = {
-      baseUrl: 'http://127.0.0.1:8118/v1', api: 'openai-completions', apiKey: 'prime-local',
-      models: [{ id: 'model-first' }],
+    for (let index = 0; index < 5_010; index += 1) {
+      models.push(primeModel('anthropic', `model-${index}`))
     }
+    const providerService = serviceWithRegistryModels(models)
+    const catalog = await providerService.catalog(true)
 
-    const catalog = await serviceWithModels({ providers: customProviders }).catalog(true)
-
+    expect(catalog.models).toHaveLength(5_000)
     expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
     const names = catalog.providers.map((provider) => provider.name)
     expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)))
-    expect(catalog.providers.some((provider) => provider.id === 'aa-first-provider')).toBe(true)
-    expect(catalog.warning).toMatch(/providers/)
-  }, 30_000)
+    expect(catalog.warning).toMatch(/301 valid providers.*retained 256.*45 omitted/)
+    expect(catalog.warning).toMatch(/5,310 valid unique models.*retained 5,000.*310 omitted/)
+    expect(catalog.warning).toContain('310 omitted by catalog limits: 45 with omitted providers and 265 beyond the model limit')
+    expectRelationalIntegrity(catalog)
+    expect(catalog.models.some((model) => model.provider === 'overflow-299')).toBe(false)
+    await expect(providerService.requireAvailableModel('overflow-299/model')).rejects.toThrow(/not found/)
+  })
+
+  it('reports only providers represented after source order exhausts the model limit', async () => {
+    const models: unknown[] = []
+    for (let index = 0; index < 5_001; index += 1) models.push(primeModel('provider-255', `model-${index}`))
+    for (let index = 0; index < 255; index += 1) models.push(primeModel(`provider-${String(index).padStart(3, '0')}`, 'model'))
+
+    const catalog = await serviceWithRegistryModels(models).catalog(true)
+
+    expect(catalog.providers).toHaveLength(MAX_CATALOG_PROVIDERS)
+    expect(catalog.models).toHaveLength(5_000)
+    expect(new Set(catalog.models.map((model) => model.provider))).toEqual(new Set(['provider-255']))
+    expect(catalog.providers.find((provider) => provider.id === 'provider-255')).toMatchObject({ modelCount: 5_000, availableModelCount: 5_000 })
+    expect(catalog.providers.find((provider) => provider.id === 'provider-000')).toMatchObject({ modelCount: 0, availableModelCount: 0 })
+    expect(catalog.warning).toContain('retained 5,000 across 1 provider (256 omitted by catalog limits')
+    expectRelationalIntegrity(catalog)
+  })
+
+  it('warns about Codex fallback only when a Codex model survives the limits', async () => {
+    const retained = await serviceWithRegistryModels(
+      [primeModel('openai-codex', 'gpt-retained')],
+      { executableModels: [] },
+    ).catalog(true)
+    expect(retained.models.map((model) => model.key)).toEqual(['openai-codex/gpt-retained'])
+    expect(retained.warning).toContain('configured Codex catalogue')
+
+    const overflowModels = Array.from({ length: 5_000 }, (_, index) => primeModel('aa-source', `model-${index}`))
+    overflowModels.push(primeModel('openai-codex', 'gpt-omitted'))
+    const overflow = await serviceWithRegistryModels(overflowModels, {
+      executableModels: overflowModels.filter((model) => (model as { provider: string }).provider !== 'openai-codex'),
+    }).catalog(true)
+
+    expect(overflow.providers.find((provider) => provider.id === 'openai-codex')).toMatchObject({ modelCount: 0, availableModelCount: 0 })
+    expect(overflow.models.some((model) => model.provider === 'openai-codex')).toBe(false)
+    expect(overflow.warning).not.toContain('configured Codex catalogue')
+  })
 
   it('stores API keys through Prime auth storage without exposing them in the catalog', async () => {
     const { providerService, authPath } = serviceWithAuthPath()


### PR DESCRIPTION
## Summary

- apply provider and model caps as one deterministic relational operation
- guarantee that every retained model references exactly one retained provider
- rebuild retained provider model counts from the final bounded model set
- keep warnings and Prime Codex fallback messaging truthful after truncation
- enforce the same bounded catalog through capabilities, cache/stale fallback, IPC toggles, schedules, launch, and `set_model`

## Root cause

Providers and models were independently sliced to their respective limits. Under source-order starvation or simultaneous overflow, retained models could reference omitted providers, retained providers could report stale counts, and warnings could claim availability that the final catalog did not contain.

## Design

A shared provider-first limiter selects bounded providers, admits only models owned by those providers, applies the model cap deterministically, and recomputes counts from the retained rows. Ordinary catalogs retain their existing order and descriptor shape.

## Isolated ancestry and diff

- base: `bce2d6eed8ec68ad604c8f75b85a5e1fd25c0f47` (current `main` at reconstruction time)
- head: `125df073f8a2760ac62ecdf163757227a8000e88`
- exactly one issue-#52 commit on the base
- GitHub-visible diff is limited to three catalog/provider implementation files and five focused backend test files
- no commits or files from rejected PR #36 remain in the ancestry or diff

## Verification

Pinned Node 24.19.0 / npm 12.0.2:

- focused provider/catalog plus downstream RPC, scheduling, IPC, and settings matrix: 10 files, 178/178 passed
- complete test surface under local host contention: 1,317 passed, 1 skipped; the sole unrelated real-clock session-catalog assertion passed 37/37 when rerun in isolation
- typecheck: passed
- lint and format check: passed (only pre-existing diagnostics outside this diff)
- production build: passed
- `git diff --check`: passed
- independent exact-tree review: no Critical, Important, or Minor findings; reviewer matrix 107/107 passed
- hosted exact-head CI: [run 31901778883](https://github.com/am-will/gooey-pi/actions/runs/31901778883) passed all six required jobs; the workflow-dispatch-only local QA package was correctly skipped

## Risk

Medium and limited to extreme catalog truncation. Exact-boundary, provider-only overflow, model-only overflow, simultaneous overflow, cache/stale fallback, visibility/toggles, schedule validation, launch, capabilities, and `set_model` paths are covered.

Fixes #52
