### PR TITLE
fix: make Privacy settings truthful

### DIFF
--- a/src/pages/settings/PrivacySettings.tsx
+++ b/src/pages/settings/PrivacySettings.tsx
@@ -1,18 +1,17 @@
-import { LockKeyhole } from 'lucide-react'
+import { Bot, LockKeyhole } from 'lucide-react'
 import type { SettingsSectionProps } from './contracts'
-import { SettingsToggle } from './SettingsToggle'
 
-export function PrivacySettings({ settings, onUpdate }: SettingsSectionProps) {
+export function PrivacySettings(_props: SettingsSectionProps) {
   return (
     <>
-      <header><h1>Privacy</h1><p>Control optional diagnostics and local data.</p></header>
+      <header><h1>Privacy</h1><p>Understand how GooeyPi stores settings and connects to agents.</p></header>
       <section className="settings-group">
-        <h2>Diagnostics</h2>
-        <SettingsToggle checked={settings.telemetry} onChange={(telemetry) => { void onUpdate({ telemetry }) }} label="Share optional diagnostics" description="Allow anonymous crash and reliability diagnostics. Prompts, files, terminal output, and provider credentials are never included." />
+        <h2>Local data</h2>
+        <div className="info-row"><LockKeyhole size={15} /><div><strong>Settings stay on this device</strong><small>Project metadata and interface settings are stored locally on this device.</small></div></div>
       </section>
       <section className="settings-group">
-        <h2>Local-first</h2>
-        <div className="info-row"><LockKeyhole size={15} /><div><strong>Your work stays on this Mac</strong><small>Project metadata and interface settings are stored locally. Provider requests follow your Prime Agent configuration.</small></div></div>
+        <h2>Agent requests</h2>
+        <div className="info-row"><Bot size={15} /><div><strong>Requests use your selected agent</strong><small>Session requests follow the selected agent and its provider configuration.</small></div></div>
       </section>
     </>
   )

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -423,6 +423,10 @@ export interface AppSettings {
   runtimePaths: Record<HarnessId, string>
   /** Legacy visibility preference retained for state compatibility; executable detection is authoritative. */
   enabledHarnesses: HarnessId[]
+  /**
+   * Legacy diagnostics preference retained for persisted-state compatibility.
+   * The Privacy UI deliberately ignores this field; any reporting use needs separate review.
+   */
   telemetry: boolean
   /** GooeyPi-managed ask_user tool, shared by every interactive harness. */
   askUserEnabled: boolean

--- a/tests/backend/privacy-settings-contract.test.ts
+++ b/tests/backend/privacy-settings-contract.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { extname, join, relative } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ session: { fromPartition: vi.fn(), defaultSession: {} } }))
+
+import { SettingsService } from '../../electron/main/settings-schedules'
+import { defaultSettings, JsonStateStore } from '../../electron/main/store'
+import { HARNESS_IDS, type HarnessId } from '../../src/types/api'
+
+const DIRECT_REFERENCE_ROOTS = ['assets/extensions', 'electron', 'src'] as const
+const DIRECT_REFERENCE_EXTENSIONS = new Set(['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx'])
+const TELEMETRY_VALUES = [false, true] as const
+const HARNESS_TELEMETRY_CASES = HARNESS_IDS.flatMap((harness) => (
+  TELEMETRY_VALUES.map((telemetry) => ({ harness, telemetry }))
+)) satisfies Array<{ harness: HarnessId; telemetry: boolean }>
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function temporaryStatePath(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'gooeypi-privacy-settings-'))
+  temporaryDirectories.push(directory)
+  return join(directory, 'state.json')
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(path)
+    return entry.isFile() && DIRECT_REFERENCE_EXTENSIONS.has(extname(entry.name)) ? [path] : []
+  })
+}
+
+describe('legacy telemetry compatibility contract', () => {
+  it('keeps the legacy preference default-off', () => {
+    expect(defaultSettings().telemetry).toBe(false)
+  })
+
+  it.each(HARNESS_IDS)('defaults an absent legacy preference off for selected agent $harness', (harness) => {
+    const statePath = temporaryStatePath()
+    writeFileSync(statePath, JSON.stringify({ version: 4, settings: { activeHarness: harness } }))
+
+    expect(new JsonStateStore(statePath).snapshot().settings).toMatchObject({ activeHarness: harness, telemetry: false })
+  })
+
+  it.each(HARNESS_TELEMETRY_CASES)('parses telemetry=$telemetry for selected agent $harness', ({ harness, telemetry }) => {
+    const statePath = temporaryStatePath()
+    writeFileSync(statePath, JSON.stringify({ version: 4, settings: { activeHarness: harness, telemetry } }))
+
+    expect(new JsonStateStore(statePath).snapshot().settings).toMatchObject({ activeHarness: harness, telemetry })
+  })
+
+  it.each(HARNESS_TELEMETRY_CASES)('durably persists telemetry=$telemetry for selected agent $harness', async ({ harness, telemetry }) => {
+    const statePath = temporaryStatePath()
+    const store = new JsonStateStore(statePath)
+    const settings = new SettingsService(store, () => '/bin/zsh')
+    await settings.update({ activeHarness: harness, telemetry })
+    await store.beginShutdown()
+
+    const persisted = JSON.parse(readFileSync(statePath, 'utf8')) as { settings: { activeHarness: HarnessId; telemetry: boolean } }
+    expect(persisted.settings).toMatchObject({ activeHarness: harness, telemetry })
+    expect(new JsonStateStore(statePath).snapshot().settings).toMatchObject({ activeHarness: harness, telemetry })
+  })
+
+  it('matches the reviewed direct telemetry source-reference allowlist', () => {
+    const references = DIRECT_REFERENCE_ROOTS
+      .flatMap(sourceFiles)
+      .flatMap((file) => readFileSync(file, 'utf8').split('\n').flatMap((line) => (
+        /\btelemetry\b/i.test(line)
+          ? [{ file: relative(process.cwd(), file), source: line.trim() }]
+          : []
+      )))
+      .sort((left, right) => left.file.localeCompare(right.file) || left.source.localeCompare(right.source))
+
+    // This intentionally lexical guard scans only the roots and extensions declared above.
+    // Exact equality rejects both unexpected references and stale/missing allowlist entries.
+    // It does not detect computed, indirect, or aliased consumers and must not be cited as
+    // semantic proof that no telemetry consumer or transport exists.
+    expect(references).toStrictEqual([
+      { file: 'electron/main/settings-schedules.ts', source: "telemetry: (value) => requireBoolean(value, 'telemetry')," },
+      { file: 'electron/main/store.ts', source: 'telemetry: false,' },
+      { file: 'electron/main/store.ts', source: "telemetry: typeof value.telemetry === 'boolean' ? value.telemetry : defaults.telemetry," },
+      { file: 'src/lib/data.ts', source: 'telemetry: false,' },
+      { file: 'src/pages/settings/contracts.ts', source: "telemetry: 'privacy'," },
+      { file: 'src/types/api.ts', source: 'telemetry: boolean' },
+    ])
+  })
+})

--- a/tests/frontend/privacy-settings.test.tsx
+++ b/tests/frontend/privacy-settings.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_SETTINGS } from '../../src/lib/data'
+import { PrivacySettings } from '../../src/pages/settings/PrivacySettings'
+import { HARNESS_IDS, type HarnessId } from '../../src/types/api'
+
+const TELEMETRY_VALUES = [false, true] as const
+const HARNESS_TELEMETRY_CASES = HARNESS_IDS.flatMap((harness) => (
+  TELEMETRY_VALUES.map((telemetry) => ({ harness, telemetry }))
+)) satisfies Array<{ harness: HarnessId; telemetry: boolean }>
+
+let root: Root
+let container: HTMLDivElement
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('PrivacySettings', () => {
+  it.each(HARNESS_TELEMETRY_CASES)('shows agent-neutral copy without an inert diagnostics control for $harness with telemetry=$telemetry', ({ harness, telemetry }) => {
+    const onUpdate = vi.fn()
+    act(() => root.render(<PrivacySettings settings={{ ...DEFAULT_SETTINGS, activeHarness: harness, telemetry }} onUpdate={onUpdate} />))
+
+    expect(container.textContent).toContain('Understand how GooeyPi stores settings and connects to agents.')
+    expect(container.textContent).toContain('Settings stay on this device')
+    expect(container.textContent).toContain('Project metadata and interface settings are stored locally on this device.')
+    expect(container.textContent).toContain('Requests use your selected agent')
+    expect(container.textContent).toContain('Session requests follow the selected agent and its provider configuration.')
+    expect(container.querySelector('input[type="checkbox"]')).toBeNull()
+    expect(container.textContent).not.toMatch(/optional diagnostics|share diagnostics|this Mac|Prime Agent/i)
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/tests/frontend/provider-settings.test.tsx
+++ b/tests/frontend/provider-settings.test.tsx
@@ -4,9 +4,8 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProviderAuthModal } from '../../src/components/ProviderAuthModal'
 import { useProviderCatalog } from '../../src/hooks/useProviderCatalog'
-import { PrivacySettings } from '../../src/pages/settings/PrivacySettings'
 import { ProviderSettings } from '../../src/pages/settings/ProviderSettings'
-import type { AppSettings, HarnessId, PrimeModelCatalog, PrimeWorkApi, RuntimeInfo } from '../../src/types/api'
+import type { HarnessId, PrimeModelCatalog, PrimeWorkApi, RuntimeInfo } from '../../src/types/api'
 
 vi.mock('../../src/components/ui', () => ({
   Modal: ({ title, children, footer }: { title: string; children: ReactNode; footer?: ReactNode }) => <div role="dialog" aria-label={title}>{children}{footer}</div>,
@@ -202,16 +201,6 @@ describe('provider settings behavior and accessibility', () => {
     expect(container.querySelector('[role="alert"]')?.textContent).toBe('Provider rejected the callback')
   })
 
-  it('persists the diagnostics toggle through the privacy settings contract', async () => {
-    const settings = { telemetry: false } as AppSettings
-    const onUpdate = vi.fn()
-    await render(<PrivacySettings settings={settings} onUpdate={onUpdate} />)
-
-    const toggle = container.querySelector<HTMLInputElement>('input[type="checkbox"]')
-    expect(toggle).not.toBeNull()
-    await click(toggle!)
-    expect(onUpdate).toHaveBeenCalledWith({ telemetry: true })
-  })
 })
 
 describe('provider runtime mutations', () => {


### PR DESCRIPTION
## Summary

- remove the visible diagnostics-sharing toggle because no reporter or uploader consumes it
- use device- and selected-agent-neutral Privacy copy for Prime, OMP, and Pi
- retain the legacy `telemetry` field, default, parser, validation, and durable persistence for schema compatibility
- add an explicitly lexical exact-source-reference allowlist over named production roots and shipped extensions
- cover every harness with both legacy values through parse, persistence, and rendered UI contracts

## Root cause

The Privacy page presented an actionable diagnostics opt-in and platform/harness-specific promises that did not match shipped behavior. The stored boolean was validated and persisted, but no production diagnostics transport consumed it.

## Design boundary

Privacy is informational until a separately reviewed diagnostics feature exists. The compatibility field remains accepted and defaults off so existing state files are not rewritten incompatibly.

The regression guard is deliberately narrow and truthful: it compares direct source references in the named production roots and shipped extensions against an exact schema/default/validation allowlist. It does **not** infer semantic consumers, computed or aliased references, or prove the absence of an indirect transport. Any direct new reference fails the guard and requires an explicit privacy review.

## Verification

Exact Node 24.19.0 / npm 12.0.2 on current `main`:

- tests-first contract: the old UI/consumer shape failed before the source change
- focused privacy/settings matrix: 45/45
- full release verification: 139 files, 1,563 passed / 1 intentional skip
- coverage: 86.13% statements, 79.17% branches, 91.38% functions, 91.65% lines
- typecheck, repository check, production build, bundle budgets, and diff-check: pass
- hermetic Electron E2E: 54/54
- React Doctor: no touched-file findings
- independent exact-head review: READY, no findings

This branch is one privacy-only commit directly on the current accepted baseline; it has no obsolete prerequisite stack.

Fixes #60
