### PR TITLE
perf: reconcile known session changes incrementally

### DIFF
--- a/electron/main/sessions.ts
+++ b/electron/main/sessions.ts
@@ -423,14 +423,32 @@ export class SessionService {
     let catalogOnly = this.catalogOnlyChange
     this.changedNames.clear()
     this.catalogOnlyChange = false
-    this.catalog.invalidateLiveCatalog()
-    const paths = (await Promise.all(names.map(async (name) => {
-      try { return await this.requireSessionPath(join(this.sessionRoot, name)) } catch { return null }
-    }))).filter((path): path is string => path !== null)
-    if (paths.length !== names.length) catalogOnly = true
+
+    let paths: string[]
+    if (!catalogOnly && names.length) {
+      const result = await this.catalog.reconcileKnownChanges(names)
+      if (result.kind === 'reconciled') {
+        paths = result.paths
+      } else {
+        paths = await this.resolveChangedSessionPaths(names)
+        if (paths.length !== names.length) catalogOnly = true
+      }
+    } else {
+      // Missing/invalid names, watcher errors, and admission overflow leave
+      // the changed catalog membership unknowable, so retain the full-scan path.
+      this.catalog.invalidateLiveCatalog()
+      paths = await this.resolveChangedSessionPaths(names)
+      if (paths.length !== names.length) catalogOnly = true
+    }
     if (!this.changeListeners.size) return
     for (const filePath of paths) this.emitChange({ filePath, harness: this.harness })
     if (catalogOnly) this.emitChange({ harness: this.harness })
+  }
+
+  private async resolveChangedSessionPaths(names: readonly string[]): Promise<string[]> {
+    return (await Promise.all(names.map(async (name) => {
+      try { return await this.requireSessionPath(join(this.sessionRoot, name)) } catch { return null }
+    }))).filter((path): path is string => path !== null)
   }
 
   private emitChange(event: SessionChangeEvent): void {

--- a/electron/main/sessions/bucketed.ts
+++ b/electron/main/sessions/bucketed.ts
@@ -1,5 +1,5 @@
 import type { Stats } from 'node:fs'
-import { readdir, realpath, stat } from 'node:fs/promises'
+import { lstat, readdir, realpath, stat } from 'node:fs/promises'
 import { basename, join, relative, sep } from 'node:path'
 import { mapLimit } from '../lib/async'
 import { isPathWithin, isRecord } from '../validation'
@@ -70,6 +70,7 @@ export function createBucketedCatalogIo(): SessionCatalogIo {
     },
     canonicalize: realpath,
     inspect: stat,
+    inspectLink: lstat,
   }
 }
 

--- a/electron/main/sessions/catalog.ts
+++ b/electron/main/sessions/catalog.ts
@@ -1,15 +1,43 @@
 import type { Stats } from 'node:fs'
-import { readdir, realpath, stat } from 'node:fs/promises'
-import { isAbsolute, join } from 'node:path'
+import { lstat, readdir, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, join, sep } from 'node:path'
 import { comparePaths, createSingleFlight, mapLimit } from '../lib/async'
 import { resolveExecutable, runProcess, type ExecutableSource } from '../process-utils'
 import { isPathWithin, isRecord } from '../validation'
 import { applyLiveMetadata, type JsonRecord, type SessionMetadata } from './metadata'
 
-interface SessionFileCandidate { filePath: string; fileStat: Stats; fingerprint: string }
+interface SessionFileCandidate {
+  name: string
+  filePath: string
+  fileStat: Stats
+  fingerprint: string
+  symbolicLink: boolean
+  ancestorPaths: readonly string[]
+}
+
+interface SessionPathIdentity {
+  dev: number
+  ino: number
+}
+
+interface SessionCatalogSnapshot {
+  revision: number
+  watchedRoot: string
+  root: string
+  ancestorIdentitiesByPath: ReadonlyMap<string, SessionPathIdentity>
+  candidatesByName: Map<string, SessionFileCandidate>
+  candidatesByPath: Map<string, SessionFileCandidate>
+  indexByPath: Map<string, number>
+  sessions: SessionMetadata[]
+}
+
+export type SessionCatalogReconcileResult =
+  | { kind: 'reconciled'; paths: string[] }
+  | { kind: 'full-scan' }
 
 const LIVE_CATALOG_TTL_MS = 2_000
 const LIVE_CATALOG_MIN_SPAWN_INTERVAL_MS = 2_000
+const FULL_SCAN = { kind: 'full-scan' } as const
 
 export interface SessionCatalogEntry {
   name: string
@@ -21,12 +49,15 @@ export interface SessionCatalogIo {
   readDirectory(path: string): Promise<readonly SessionCatalogEntry[]>
   canonicalize(path: string): Promise<string>
   inspect(path: string): Promise<Stats>
+  /** `lstat`-equivalent seam used to reject a known regular file that became a symlink. */
+  inspectLink?(path: string): Promise<Stats>
 }
 
 const nodeSessionCatalogIo: SessionCatalogIo = {
   readDirectory: (path) => readdir(path, { withFileTypes: true }),
   canonicalize: realpath,
   inspect: stat,
+  inspectLink: lstat,
 }
 
 /** Derives a creation timestamp from a session file name for pre-I/O ordering; `undefined` means no encoded timestamp. */
@@ -49,6 +80,45 @@ function compareCandidateNames(left: string, right: string, nameTimestamp: Sessi
   return comparePaths(right, left)
 }
 
+function catalogNameKey(name: string): string {
+  return sep === '/' ? name : name.split(sep).join('/')
+}
+
+function isSafeRelativeName(name: string): boolean {
+  if (!name || name.length > 4_096 || name.includes('\0') || isAbsolute(name)) return false
+  const segments = name.split('/')
+  return segments.every((segment) => segment.length > 0 && segment.length <= 255
+    && segment !== '.' && segment !== '..' && !segment.startsWith('.'))
+}
+
+function sameIdentity(left: SessionPathIdentity, right: SessionPathIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino
+}
+
+function pathIdentity(stat: Stats): SessionPathIdentity {
+  return { dev: stat.dev, ino: stat.ino }
+}
+
+function sameLeafSnapshot(expected: Stats, current: Stats): boolean {
+  return current.isFile()
+    && expected.dev === current.dev
+    && expected.ino === current.ino
+    && expected.size === current.size
+    && expected.mtimeMs === current.mtimeMs
+    && expected.ctimeMs === current.ctimeMs
+    && expected.mode === current.mode
+}
+
+function ancestorPathsForName(watchedRoot: string, name: string): string[] {
+  const ancestors = [watchedRoot]
+  let current = watchedRoot
+  for (const segment of name.split('/').slice(0, -1)) {
+    current = join(current, segment)
+    ancestors.push(current)
+  }
+  return ancestors
+}
+
 export function boundedSessionDiscoveryNames(names: readonly string[], maxSessionFiles: number, nameTimestamp: SessionNameTimestamp = timestampFromSessionName): string[] {
   const budget = Math.max(0, Math.ceil(maxSessionFiles))
   return [...names].sort((left, right) => compareCandidateNames(left, right, nameTimestamp)).slice(0, budget)
@@ -65,6 +135,16 @@ export class SessionMetadataCatalog {
   private readonly metadataCache = new Map<string, SessionMetadata>()
   private readonly metadataRequests = createSingleFlight<string, SessionMetadata>()
   private readonly canonicalByName = new Map<string, { canonical: string; dev: number; ino: number }>()
+  private snapshot: SessionCatalogSnapshot | null = null
+  private preparedRevision: number | null = null
+  private preparedView: { revision: number; promise: Promise<SessionMetadata[]> } | null = null
+  private reconcileTail: Promise<void> = Promise.resolve()
+  private pendingReconciles = 0
+  private viewCache: {
+    snapshot: SessionCatalogSnapshot
+    live: ReadonlyMap<string, JsonRecord>
+    sessions: SessionMetadata[]
+  } | null = null
 
   constructor(
     private readonly sessionRoot: () => string,
@@ -82,6 +162,8 @@ export class SessionMetadataCatalog {
    */
   invalidateLiveCatalog(): void {
     this.catalogRevision += 1
+    this.preparedRevision = null
+    this.preparedView = null
   }
 
   /** Live Prime Agent session records keyed by canonical session file path. */
@@ -90,48 +172,241 @@ export class SessionMetadataCatalog {
   }
 
   async all(): Promise<SessionMetadata[]> {
+    await this.waitForReconciliations()
     const revision = this.catalogRevision
     const executable = resolveExecutable(this.primeAgentPath)
+    const snapshot = this.snapshot
+    if (snapshot?.revision === revision && this.preparedRevision === revision) {
+      const prepared = this.preparedView
+      if (prepared?.revision === revision) return prepared.promise
+      const promise = this.materialize(snapshot, executable).finally(() => {
+        if (this.preparedView?.promise !== promise) return
+        this.preparedView = null
+        if (this.preparedRevision === revision) this.preparedRevision = null
+      })
+      this.preparedView = { revision, promise }
+      return promise
+    }
     return this.sessionScanRequests.run(`${revision}\0${executable ?? ''}`, () => this.scan(revision, executable))
+  }
+
+  // Reconcile known watcher paths; uncertainty falls back to a full scan.
+  reconcileKnownChanges(names: readonly string[]): Promise<SessionCatalogReconcileResult> {
+    const normalized = [...new Set(names.map(catalogNameKey))]
+    const revision = ++this.catalogRevision
+    this.preparedRevision = null
+    this.preparedView = null
+    this.pendingReconciles += 1
+    const operation = this.reconcileTail.then(async () => {
+      try {
+        return await this.performReconciliation(normalized, revision)
+      } catch {
+        return FULL_SCAN
+      } finally {
+        this.pendingReconciles -= 1
+      }
+    })
+    this.reconcileTail = operation.then(() => undefined, () => undefined)
+    return operation
+  }
+
+  private async waitForReconciliations(): Promise<void> {
+    while (true) {
+      const tail = this.reconcileTail
+      await tail
+      if (tail === this.reconcileTail && this.pendingReconciles === 0) return
+    }
+  }
+
+  private async performReconciliation(names: readonly string[], revision: number): Promise<SessionCatalogReconcileResult> {
+    const baseline = this.snapshot
+    if (!names.length || !baseline || baseline.revision !== revision - 1) return FULL_SCAN
+    const candidates = names.map((name) => baseline.candidatesByName.get(name))
+    if (candidates.some((candidate) => !candidate || candidate.symbolicLink)) {
+      for (const [index, candidate] of candidates.entries()) {
+        if (!candidate) continue
+        this.metadataCache.delete(candidate.fingerprint)
+        if (candidate.symbolicLink) this.canonicalByName.delete(names[index])
+      }
+      return FULL_SCAN
+    }
+    const knownCandidates = candidates as SessionFileCandidate[]
+    if (!await this.ancestorsUnchanged(baseline, knownCandidates)) {
+      for (const name of names) this.canonicalByName.delete(name)
+      return FULL_SCAN
+    }
+
+    for (const candidate of knownCandidates) this.metadataCache.delete(candidate.fingerprint)
+    const refreshed = await mapLimit(names, 6, async (name) => {
+      const previous = baseline.candidatesByName.get(name)!
+      const watchedPath = join(baseline.watchedRoot, name)
+      if (!this.io.inspectLink) return null
+      let linkStat: Stats
+      let fileStat: Stats
+      let canonical: string
+      try {
+        linkStat = await this.io.inspectLink(watchedPath)
+        if (!linkStat.isFile() || linkStat.isSymbolicLink()) {
+          this.canonicalByName.delete(name)
+          return null
+        }
+        fileStat = await this.io.inspect(watchedPath)
+        canonical = await this.io.canonicalize(watchedPath)
+      } catch {
+        this.canonicalByName.delete(name)
+        return null
+      }
+      if (!fileStat.isFile() || !sameIdentity(linkStat, fileStat) || !sameIdentity(previous.fileStat, fileStat)
+        || baseline.candidatesByPath.get(previous.filePath) !== previous
+        || canonical !== previous.filePath || !isPathWithin(baseline.root, canonical)) {
+        this.canonicalByName.delete(name)
+        return null
+      }
+
+      const candidate: SessionFileCandidate = {
+        name,
+        filePath: previous.filePath,
+        fileStat,
+        fingerprint: `${previous.filePath}\0${fileStat.mtimeMs}\0${fileStat.size}`,
+        symbolicLink: false,
+        ancestorPaths: previous.ancestorPaths,
+      }
+      let metadata: SessionMetadata
+      try { metadata = await this.readMetadata(candidate.filePath, fileStat) } catch { return null }
+
+      let verifiedLink: Stats
+      let verified: Stats
+      let verifiedCanonical: string
+      try {
+        [verifiedLink, verified, verifiedCanonical] = await Promise.all([
+          this.io.inspectLink(watchedPath),
+          this.io.inspect(watchedPath),
+          this.io.canonicalize(watchedPath),
+        ])
+      } catch {
+        this.canonicalByName.delete(name)
+        return null
+      }
+      if (!verifiedLink.isFile() || verifiedLink.isSymbolicLink()
+        || !sameIdentity(verifiedLink, verified) || !sameLeafSnapshot(fileStat, verified)
+        || verifiedCanonical !== previous.filePath || !isPathWithin(baseline.root, verifiedCanonical)) {
+        this.canonicalByName.delete(name)
+        return null
+      }
+      return { name, previous, candidate, metadata: { ...metadata } }
+    })
+    if (refreshed.length !== names.length) return FULL_SCAN
+    if (!await this.ancestorsUnchanged(baseline, knownCandidates)) {
+      for (const name of names) this.canonicalByName.delete(name)
+      return FULL_SCAN
+    }
+
+    const candidatesByName = new Map(baseline.candidatesByName)
+    const candidatesByPath = new Map(baseline.candidatesByPath)
+    const metadataByPath = new Map(baseline.sessions.map((session) => [session.filePath, session]))
+    for (const update of refreshed) {
+      if (!baseline.indexByPath.has(update.previous.filePath)) return FULL_SCAN
+      candidatesByName.set(update.name, update.candidate)
+      candidatesByPath.set(update.candidate.filePath, update.candidate)
+      metadataByPath.set(update.candidate.filePath, update.metadata)
+      this.canonicalByName.set(update.name, {
+        canonical: update.candidate.filePath,
+        dev: update.candidate.fileStat.dev,
+        ino: update.candidate.fileStat.ino,
+      })
+      this.metadataCache.set(update.candidate.fingerprint, update.metadata)
+    }
+    const orderedCandidates = [...candidatesByPath.values()]
+      .sort((left, right) => right.fileStat.mtimeMs - left.fileStat.mtimeMs || comparePaths(left.filePath, right.filePath))
+    const sessions = orderedCandidates.map((candidate) => metadataByPath.get(candidate.filePath)!)
+    const next: SessionCatalogSnapshot = {
+      revision,
+      watchedRoot: baseline.watchedRoot,
+      root: baseline.root,
+      ancestorIdentitiesByPath: baseline.ancestorIdentitiesByPath,
+      candidatesByName,
+      candidatesByPath,
+      indexByPath: new Map(sessions.map((session, index) => [session.filePath, index])),
+      sessions,
+    }
+    // Reconciles are serialized. An older result remains a private base for a
+    // queued newer result, but only the newest revision is prepared for readers.
+    this.snapshot = next
+    if (this.catalogRevision === revision) this.preparedRevision = revision
+    return { kind: 'reconciled', paths: names.map((name) => candidatesByName.get(name)!.filePath) }
   }
 
   private async scan(revision: number, executable: string | null): Promise<SessionMetadata[]> {
     let entries: readonly SessionCatalogEntry[]
     let root: string
+    let rootStat: Stats
+    const watchedRoot = this.sessionRoot()
     try {
-      [entries, root] = await Promise.all([
-        this.io.readDirectory(this.sessionRoot()),
-        this.io.canonicalize(this.sessionRoot()),
+      [entries, root, rootStat] = await Promise.all([
+        this.io.readDirectory(watchedRoot),
+        this.io.canonicalize(watchedRoot),
+        this.io.inspect(watchedRoot),
       ])
     } catch { return [] }
+    if (!rootStat.isDirectory()) return []
 
     // Timestamp-encoding names (Prime UUIDv7, OMP ISO prefixes) expose creation
     // order without per-entry I/O. Admit a bounded deterministic set before
     // canonicalization and stat; legacy names fall back to reverse lexical order.
+    const entriesByName = new Map<string, { symbolicLink: boolean }>()
+    for (const entry of entries) {
+      if (!((entry.isFile?.() ?? true) || (entry.isSymbolicLink?.() ?? false))) continue
+      const name = catalogNameKey(entry.name)
+      if (!name.endsWith('.jsonl') || !isSafeRelativeName(name) || entriesByName.has(name)) continue
+      entriesByName.set(name, { symbolicLink: entry.isSymbolicLink?.() === true })
+    }
     const names = boundedSessionDiscoveryNames(
-      entries
-        .filter((entry) => (entry.isFile?.() ?? true) || (entry.isSymbolicLink?.() ?? false))
-        .map((entry) => entry.name)
-        .filter((name) => name.endsWith('.jsonl') && !name.startsWith('.')),
+      [...entriesByName.keys()],
       this.maxSessionFiles,
       this.nameTimestamp,
     )
+    const ancestorPathsByName = new Map(names.map((name) => [name, ancestorPathsForName(watchedRoot, name)]))
+    const intermediatePaths = [...new Set([...ancestorPathsByName.values()].flatMap((paths) => paths.slice(1)))]
+    const inspectedIntermediates = await mapLimit(intermediatePaths, 32, async (path) => {
+      try {
+        const pathStat = await this.io.inspect(path)
+        return pathStat.isDirectory() ? { path, identity: pathIdentity(pathStat) } : null
+      } catch { return null }
+    })
+    const ancestorIdentitiesByPath = new Map<string, SessionPathIdentity>([
+      [watchedRoot, pathIdentity(rootStat)],
+      ...inspectedIntermediates.map(({ path, identity }) => [path, identity] as const),
+    ])
     const discovered = await mapLimit(names, 32, async (name): Promise<SessionFileCandidate | null> => {
       try {
         // stat() follows symlinks, so an unchanged dev/ino identity lets the
         // cached canonical path stand in for a realpath call per entry.
-        const fileStat = await this.io.inspect(join(root, name))
+        const watchedPath = join(watchedRoot, name)
+        const ancestorPaths = ancestorPathsByName.get(name)!
+        if (ancestorPaths.some((path) => !ancestorIdentitiesByPath.has(path))) return null
+        const fileStat = await this.io.inspect(watchedPath)
         if (!fileStat.isFile()) {
           this.canonicalByName.delete(name)
           return null
         }
-        const known = this.canonicalByName.get(name)
+        const symbolicLink = entriesByName.get(name)?.symbolicLink === true
+        const known = symbolicLink ? undefined : this.canonicalByName.get(name)
         const filePath = known && known.dev === fileStat.dev && known.ino === fileStat.ino
           ? known.canonical
-          : await this.io.canonicalize(join(root, name))
+          : await this.io.canonicalize(watchedPath)
         this.canonicalByName.set(name, { canonical: filePath, dev: fileStat.dev, ino: fileStat.ino })
-        if (!isPathWithin(root, filePath)) return null
-        return { filePath, fileStat, fingerprint: `${filePath}\0${fileStat.mtimeMs}\0${fileStat.size}` }
+        if (!isPathWithin(root, filePath)) {
+          this.canonicalByName.delete(name)
+          return null
+        }
+        return {
+          name,
+          filePath,
+          fileStat,
+          fingerprint: `${filePath}\0${fileStat.mtimeMs}\0${fileStat.size}`,
+          symbolicLink,
+          ancestorPaths,
+        }
       } catch {
         this.canonicalByName.delete(name)
         return null
@@ -144,7 +419,9 @@ export class SessionMetadataCatalog {
       }
     }
     const byCanonicalPath = new Map<string, SessionFileCandidate>()
-    for (const candidate of discovered) byCanonicalPath.set(candidate.filePath, candidate)
+    for (const candidate of discovered.sort((left, right) => comparePaths(left.name, right.name))) {
+      if (!byCanonicalPath.has(candidate.filePath)) byCanonicalPath.set(candidate.filePath, candidate)
+    }
     const selected = [...byCanonicalPath.values()]
       .sort((a, b) => b.fileStat.mtimeMs - a.fileStat.mtimeMs || comparePaths(a.filePath, b.filePath))
       .slice(0, this.maxSessionFiles)
@@ -157,15 +434,60 @@ export class SessionMetadataCatalog {
 
     const catalogPromise = this.liveCatalog(executable)
     const metadata = await mapLimit(selected, 6, async (candidate) => {
-      try { return await this.cachedMetadata(candidate, revision) } catch { return null }
+      try { return { candidate, metadata: await this.cachedMetadata(candidate, revision) } } catch { return null }
     })
     const catalog = await catalogPromise
-    return metadata.map((original) => {
+    const metadataByPath = new Map(metadata.map((entry) => [entry.candidate.filePath, entry.metadata]))
+    const successful = selected.filter((candidate) => metadataByPath.has(candidate.filePath))
+    const sessions = successful.map((candidate) => metadataByPath.get(candidate.filePath)!)
+    const activeAncestorPaths = new Set(successful.flatMap((candidate) => candidate.ancestorPaths))
+    const snapshot: SessionCatalogSnapshot = {
+      revision,
+      watchedRoot,
+      root,
+      ancestorIdentitiesByPath: new Map([...ancestorIdentitiesByPath].filter(([path]) => activeAncestorPaths.has(path))),
+      candidatesByName: new Map(successful.map((candidate) => [candidate.name, candidate])),
+      candidatesByPath: new Map(successful.map((candidate) => [candidate.filePath, candidate])),
+      indexByPath: new Map(sessions.map((session, index) => [session.filePath, index])),
+      sessions,
+    }
+    if (this.catalogRevision === revision) this.snapshot = snapshot
+    return this.materialize(snapshot, executable, catalog)
+  }
+
+  private async ancestorsUnchanged(snapshot: SessionCatalogSnapshot, candidates: readonly SessionFileCandidate[]): Promise<boolean> {
+    const paths = [...new Set(candidates.flatMap((candidate) => candidate.ancestorPaths))]
+    const current = await mapLimit(paths, 8, async (path) => {
+      const expected = snapshot.ancestorIdentitiesByPath.get(path)
+      if (!expected) return null
+      try {
+        const pathStat = await this.io.inspect(path)
+        return pathStat.isDirectory() && sameIdentity(expected, pathStat) ? path : null
+      } catch { return null }
+    })
+    return current.length === paths.length
+  }
+
+  private async materialize(
+    snapshot: SessionCatalogSnapshot,
+    executable: string | null,
+    knownLive?: ReadonlyMap<string, JsonRecord>,
+  ): Promise<SessionMetadata[]> {
+    const live = knownLive ?? await this.liveCatalog(executable)
+    if (!live.size) return snapshot.sessions
+    const previous = this.viewCache
+    const sessions = snapshot.sessions.map((original) => {
+      const overlay = live.get(original.filePath)
+      if (!overlay) return original
+      const previousIndex = previous?.snapshot.indexByPath.get(original.filePath)
+      if (previous && previous.live === live && previousIndex !== undefined
+        && previous.snapshot.sessions[previousIndex] === original) return previous.sessions[previousIndex]
       const item = { ...original }
-      const live = catalog.get(item.filePath)
-      if (live) applyLiveMetadata(item, live)
+      applyLiveMetadata(item, overlay)
       return item
     })
+    this.viewCache = { snapshot, live, sessions }
+    return sessions
   }
 
   private async cachedMetadata(candidate: SessionFileCandidate, revision: number): Promise<SessionMetadata> {

--- a/tests/backend/session-catalog-reconcile.test.ts
+++ b/tests/backend/session-catalog-reconcile.test.ts
@@ -1,0 +1,544 @@
+import {
+  appendFileSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  type Stats,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createBucketedCatalogIo } from '../../electron/main/sessions/bucketed'
+import { SessionMetadataCatalog, type SessionCatalogEntry, type SessionCatalogIo } from '../../electron/main/sessions/catalog'
+import type { SessionMetadata } from '../../electron/main/sessions/metadata'
+
+const root = '/sessions'
+const realDirectories: string[] = []
+
+interface FileState {
+  dev: number
+  ino: number
+  mtimeMs: number
+  size: number
+  version: number
+  canonical?: string
+  symbolicLink?: boolean
+}
+
+function sessionName(index: number): string {
+  return `session-${index.toString().padStart(5, '0')}.jsonl`
+}
+
+function metadataFor(filePath: string, version: number): SessionMetadata {
+  const name = filePath.slice(filePath.lastIndexOf('/') + 1, -'.jsonl'.length)
+  return {
+    id: `${name}-v${version}`,
+    filePath,
+    projectPath: '/project',
+    title: `${name} version ${version}`,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: new Date(Date.parse('2025-01-01T00:00:00.000Z') + version * 1_000).toISOString(),
+    status: 'idle',
+    depth: 0,
+    pinned: false,
+    unread: false,
+  }
+}
+
+function fakeStats(state: FileState): Stats {
+  return {
+    dev: state.dev,
+    ino: state.ino,
+    mtimeMs: state.mtimeMs,
+    size: state.size,
+    isFile: () => true,
+    isDirectory: () => false,
+  } as Stats
+}
+
+function fakeDirectoryStats(state: FileState): Stats {
+  return {
+    ...fakeStats(state),
+    isFile: () => false,
+    isDirectory: () => true,
+  } as Stats
+}
+
+function fixture(count: number, maxSessionFiles = count) {
+  const files = new Map<string, FileState>()
+  const rootState: FileState = { dev: 1, ino: 1_000_000, mtimeMs: 1, size: 0, version: 0 }
+  for (let index = 0; index < count; index += 1) {
+    files.set(sessionName(index), {
+      dev: 1,
+      ino: index + 1,
+      mtimeMs: index + 1,
+      size: 100,
+      version: 0,
+    })
+  }
+  const entries = vi.fn(async (): Promise<readonly SessionCatalogEntry[]> => [...files].map(([name, state]) => ({
+    name,
+    isFile: () => true,
+    isSymbolicLink: () => state.symbolicLink === true,
+  })))
+  const canonicalize = vi.fn(async (path: string) => {
+    if (path === root) return root
+    const name = path.slice(path.lastIndexOf('/') + 1)
+    const state = files.get(name)
+    if (!state) throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    return state.canonical ?? path
+  })
+  const inspect = vi.fn(async (path: string) => {
+    if (path === root) return fakeDirectoryStats(rootState)
+    const name = path.slice(path.lastIndexOf('/') + 1)
+    const state = files.get(name)
+    if (!state) throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    return fakeStats(state)
+  })
+  const inspectLink = vi.fn(async (path: string) => {
+    const name = path.slice(path.lastIndexOf('/') + 1)
+    const state = files.get(name)
+    if (!state) throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    return {
+      ...fakeStats(state),
+      isFile: () => state.symbolicLink !== true,
+      isSymbolicLink: () => state.symbolicLink === true,
+    } as Stats
+  })
+  const readMetadata = vi.fn(async (filePath: string) => {
+    const name = filePath.slice(filePath.lastIndexOf('/') + 1)
+    const state = files.get(name)
+    if (!state) throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+    return metadataFor(filePath, state.version)
+  })
+  const io: SessionCatalogIo = { readDirectory: entries, canonicalize, inspect, inspectLink }
+  const catalog = new SessionMetadataCatalog(() => root, null, maxSessionFiles, readMetadata, io)
+  return { catalog, files, entries, canonicalize, inspect, inspectLink, readMetadata }
+}
+
+function byPath(records: readonly SessionMetadata[]): Map<string, SessionMetadata> {
+  return new Map(records.map((record) => [record.filePath, record]))
+}
+
+function deferred<T>() {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolve) => { resolvePromise = resolve })
+  return { promise, resolve: resolvePromise }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const directory of realDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+describe('SessionMetadataCatalog known-file reconciliation', () => {
+  it('updates one known file in a 5,000-file snapshot with no enumeration and constant candidate inspection', async () => {
+    const { catalog, files, entries, canonicalize, inspect, inspectLink, readMetadata } = fixture(5_000)
+    const changedName = sessionName(2_500)
+    const unchangedName = sessionName(1_000)
+    const initial = await catalog.all()
+    const initialByPath = byPath(initial)
+
+    expect(entries).toHaveBeenCalledOnce()
+    expect(canonicalize).toHaveBeenCalledTimes(5_001)
+    expect(inspect).toHaveBeenCalledTimes(10_001)
+    expect(readMetadata).toHaveBeenCalledTimes(5_000)
+
+    const changed = files.get(changedName)!
+    Object.assign(changed, { mtimeMs: 10_000, size: 150, version: 1 })
+    await expect(catalog.reconcileKnownChanges([changedName])).resolves.toEqual({
+      kind: 'reconciled',
+      paths: [`${root}/${changedName}`],
+    })
+    const refreshed = await catalog.all()
+    const refreshedByPath = byPath(refreshed)
+
+    expect(entries).toHaveBeenCalledOnce()
+    expect(canonicalize).toHaveBeenCalledTimes(5_003)
+    expect(inspect).toHaveBeenCalledTimes(10_005)
+    expect(inspectLink).toHaveBeenCalledTimes(2)
+    expect(readMetadata).toHaveBeenCalledTimes(5_001)
+    expect(refreshedByPath.get(`${root}/${changedName}`)?.id).toBe('session-02500-v1')
+    expect(refreshedByPath.get(`${root}/${changedName}`)).not.toBe(initialByPath.get(`${root}/${changedName}`))
+    expect(refreshedByPath.get(`${root}/${unchangedName}`)).toBe(initialByPath.get(`${root}/${unchangedName}`))
+  })
+
+  it('reconciles multiple known files in one batch and preserves every untouched metadata identity', async () => {
+    const { catalog, files, entries, inspect } = fixture(4)
+    const initial = await catalog.all()
+    const initialByPath = byPath(initial)
+    for (const index of [1, 3]) Object.assign(files.get(sessionName(index))!, {
+      mtimeMs: 100 + index,
+      size: 200 + index,
+      version: 1,
+    })
+
+    const beforeInspect = inspect.mock.calls.length
+    await expect(catalog.reconcileKnownChanges([sessionName(1), sessionName(3), sessionName(1)])).resolves.toMatchObject({
+      kind: 'reconciled',
+      paths: [`${root}/${sessionName(1)}`, `${root}/${sessionName(3)}`],
+    })
+    const refreshed = byPath(await catalog.all())
+
+    expect(entries).toHaveBeenCalledOnce()
+    // Two leaf checks per changed file plus one root-identity check before and
+    // after the batch: constant in catalog size and deduplicated across files.
+    expect(inspect.mock.calls.length - beforeInspect).toBe(6)
+    expect(refreshed.get(`${root}/${sessionName(1)}`)?.id).toBe('session-00001-v1')
+    expect(refreshed.get(`${root}/${sessionName(3)}`)?.id).toBe('session-00003-v1')
+    expect(refreshed.get(`${root}/${sessionName(0)}`)).toBe(initialByPath.get(`${root}/${sessionName(0)}`))
+    expect(refreshed.get(`${root}/${sessionName(2)}`)).toBe(initialByPath.get(`${root}/${sessionName(2)}`))
+  })
+
+  it('falls back to a full scan for absent baselines, admission changes, deletion, and identity changes', async () => {
+    const absent = fixture(1)
+    await expect(absent.catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    await absent.catalog.all()
+    expect(absent.entries).toHaveBeenCalledOnce()
+
+    const admission = fixture(1, 1)
+    expect((await admission.catalog.all())[0]?.id).toBe('session-00000-v0')
+    admission.files.set(sessionName(1), { dev: 1, ino: 2, mtimeMs: 2, size: 100, version: 0 })
+    await expect(admission.catalog.reconcileKnownChanges([sessionName(1)])).resolves.toEqual({ kind: 'full-scan' })
+    expect((await admission.catalog.all())[0]?.id).toBe('session-00001-v0')
+    expect(admission.entries).toHaveBeenCalledTimes(2)
+
+    const deletion = fixture(2)
+    await deletion.catalog.all()
+    deletion.files.delete(sessionName(0))
+    await expect(deletion.catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    expect((await deletion.catalog.all()).map(({ id }) => id)).not.toContain('session-00000-v0')
+    expect(deletion.entries).toHaveBeenCalledTimes(2)
+
+    const identity = fixture(1)
+    await identity.catalog.all()
+    Object.assign(identity.files.get(sessionName(0))!, { ino: 99, mtimeMs: 2, size: 101, version: 1 })
+    await expect(identity.catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    expect((await identity.catalog.all())[0]?.id).toBe('session-00000-v1')
+    expect(identity.entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('fully rescans invalid names, renames, and explicit invalidation after a prepared reconcile', async () => {
+    const invalid = fixture(1)
+    await invalid.catalog.all()
+    await expect(invalid.catalog.reconcileKnownChanges(['../escape.jsonl'])).resolves.toEqual({ kind: 'full-scan' })
+    await invalid.catalog.all()
+    expect(invalid.entries).toHaveBeenCalledTimes(2)
+
+    const renamed = fixture(1)
+    await renamed.catalog.all()
+    const previousName = sessionName(0)
+    const replacementName = sessionName(1)
+    renamed.files.delete(previousName)
+    renamed.files.set(replacementName, { dev: 1, ino: 2, mtimeMs: 2, size: 100, version: 0 })
+    await expect(renamed.catalog.reconcileKnownChanges([previousName, replacementName])).resolves.toEqual({ kind: 'full-scan' })
+    expect((await renamed.catalog.all()).map(({ id }) => id)).toEqual(['session-00001-v0'])
+    expect(renamed.entries).toHaveBeenCalledTimes(2)
+
+    const forced = fixture(1)
+    await forced.catalog.all()
+    Object.assign(forced.files.get(sessionName(0))!, { mtimeMs: 2, size: 110, version: 1 })
+    await expect(forced.catalog.reconcileKnownChanges([sessionName(0)])).resolves.toMatchObject({ kind: 'reconciled' })
+    forced.catalog.invalidateLiveCatalog()
+    await forced.catalog.all()
+    expect(forced.entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('fully rescans symlinks and excludes a changed identity that escapes containment', async () => {
+    const symlink = fixture(1)
+    symlink.files.get(sessionName(0))!.symbolicLink = true
+    await symlink.catalog.all()
+    await expect(symlink.catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    await symlink.catalog.all()
+    expect(symlink.entries).toHaveBeenCalledTimes(2)
+
+    const escaped = fixture(1)
+    await escaped.catalog.all()
+    Object.assign(escaped.files.get(sessionName(0))!, {
+      ino: 42,
+      mtimeMs: 2,
+      size: 101,
+      version: 1,
+      canonical: '/outside/session.jsonl',
+    })
+    await expect(escaped.catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    await expect(escaped.catalog.all()).resolves.toEqual([])
+    expect(escaped.entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back when canonical containment changes despite an unchanged file identity', async () => {
+    const { catalog, files, entries } = fixture(1)
+    await catalog.all()
+    Object.assign(files.get(sessionName(0))!, {
+      mtimeMs: 2,
+      size: 101,
+      version: 1,
+      canonical: '/outside/session.jsonl',
+    })
+
+    await expect(catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    await expect(catalog.all()).resolves.toEqual([])
+
+    expect(entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back when the watched root alias changes its canonical target', async () => {
+    const name = sessionName(0)
+    let moved = false
+    const fileState: FileState = { dev: 1, ino: 1, mtimeMs: 1, size: 100, version: 0 }
+    const entries = vi.fn(async (): Promise<readonly SessionCatalogEntry[]> => [{ name, isFile: () => true }])
+    const canonicalize = vi.fn(async (path: string) => {
+      if (path === '/watch') return moved ? '/outside' : root
+      if (path === `/watch/${name}`) return moved ? `/outside/${name}` : `${root}/${name}`
+      return path
+    })
+    const io: SessionCatalogIo = {
+      readDirectory: entries,
+      canonicalize,
+      inspect: async (path) => path === '/watch'
+        ? fakeDirectoryStats({ dev: 1, ino: 2, mtimeMs: 1, size: 0, version: 0 })
+        : fakeStats(fileState),
+      inspectLink: async () => ({ ...fakeStats(fileState), isSymbolicLink: () => false } as Stats),
+    }
+    const catalog = new SessionMetadataCatalog(
+      () => '/watch',
+      null,
+      1,
+      async (filePath) => metadataFor(filePath, 0),
+      io,
+    )
+    await catalog.all()
+    moved = true
+
+    await expect(catalog.reconcileKnownChanges([name])).resolves.toEqual({ kind: 'full-scan' })
+    await catalog.all()
+
+    expect(entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back when a previously regular watched file becomes a symlink without changing target identity', async () => {
+    const { catalog, files, entries } = fixture(1)
+    await catalog.all()
+    files.get(sessionName(0))!.symbolicLink = true
+
+    await expect(catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    await catalog.all()
+
+    expect(entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('discards metadata when a regular file becomes a same-target symlink during reconciliation', async () => {
+    const { catalog, files, entries, readMetadata } = fixture(1)
+    await catalog.all()
+    const state = files.get(sessionName(0))!
+    Object.assign(state, { mtimeMs: 2, size: 110, version: 1 })
+    readMetadata.mockImplementationOnce(async (filePath: string) => {
+      state.symbolicLink = true
+      return metadataFor(filePath, state.version)
+    })
+
+    await expect(catalog.reconcileKnownChanges([sessionName(0)])).resolves.toEqual({ kind: 'full-scan' })
+    await catalog.all()
+
+    expect(entries).toHaveBeenCalledTimes(2)
+  })
+
+  it('fully rescans when the watched root is replaced and the original leaf is hard-linked back', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'gooeypi-session-root-identity-'))
+    realDirectories.push(parent)
+    const watchedRoot = join(parent, 'sessions')
+    const displacedRoot = join(parent, 'sessions-displaced')
+    const name = 'known.jsonl'
+    const originalFile = join(watchedRoot, name)
+    mkdirSync(watchedRoot)
+    writeFileSync(originalFile, '0')
+
+    const readDirectory = vi.fn(async (path: string): Promise<readonly SessionCatalogEntry[]> => readdirSync(path, { withFileTypes: true }))
+    const io: SessionCatalogIo = {
+      readDirectory,
+      canonicalize: async (path) => realpathSync(path),
+      inspect: async (path) => statSync(path),
+      inspectLink: async (path) => lstatSync(path),
+    }
+    const catalog = new SessionMetadataCatalog(
+      () => watchedRoot,
+      null,
+      1,
+      async (filePath) => metadataFor(filePath, readFileSync(filePath, 'utf8').length),
+      io,
+    )
+    await expect(catalog.all()).resolves.toMatchObject([{ id: 'known-v1' }])
+
+    appendFileSync(originalFile, '-changed')
+    renameSync(watchedRoot, displacedRoot)
+    mkdirSync(watchedRoot)
+    const displacedFile = join(displacedRoot, name)
+    const replacementFile = join(watchedRoot, name)
+    linkSync(displacedFile, replacementFile)
+    expect({ dev: statSync(replacementFile).dev, ino: statSync(replacementFile).ino }).toEqual({
+      dev: statSync(displacedFile).dev,
+      ino: statSync(displacedFile).ino,
+    })
+
+    await expect(catalog.reconcileKnownChanges([name])).resolves.toEqual({ kind: 'full-scan' })
+    await expect(catalog.all()).resolves.toMatchObject([{ id: 'known-v9' }])
+    expect(readDirectory).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not publish staged metadata when a bucket is replaced with a hard link during the read', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'gooeypi-session-bucket-identity-'))
+    realDirectories.push(parent)
+    const watchedRoot = join(parent, 'sessions')
+    const bucket = join(watchedRoot, 'project-bucket')
+    const displacedBucket = join(parent, 'project-bucket-displaced')
+    const fileName = 'known.jsonl'
+    const originalFile = join(bucket, fileName)
+    mkdirSync(bucket, { recursive: true })
+    writeFileSync(originalFile, '0')
+
+    const bucketedIo = createBucketedCatalogIo()
+    const readDirectory = vi.fn((path: string) => bucketedIo.readDirectory(path))
+    const io: SessionCatalogIo = { ...bucketedIo, readDirectory }
+    const readStarted = deferred<void>()
+    const releaseRead = deferred<void>()
+    let reads = 0
+    const readMetadata = vi.fn(async (filePath: string) => {
+      reads += 1
+      if (reads === 1) return { ...metadataFor(filePath, 0), id: 'baseline' }
+      if (reads === 2) {
+        readStarted.resolve()
+        await releaseRead.promise
+        return { ...metadataFor(filePath, 1), id: 'staged-stale' }
+      }
+      return { ...metadataFor(filePath, 2), id: 'rescanned-fresh' }
+    })
+    const catalog = new SessionMetadataCatalog(() => watchedRoot, null, 1, readMetadata, io)
+    await expect(catalog.all()).resolves.toMatchObject([{ id: 'baseline' }])
+
+    appendFileSync(originalFile, '-changed')
+    const reconciliation = catalog.reconcileKnownChanges([`project-bucket/${fileName}`])
+    await readStarted.promise
+    renameSync(bucket, displacedBucket)
+    mkdirSync(bucket)
+    const displacedFile = join(displacedBucket, fileName)
+    const replacementFile = join(bucket, fileName)
+    linkSync(displacedFile, replacementFile)
+    expect({ dev: statSync(replacementFile).dev, ino: statSync(replacementFile).ino }).toEqual({
+      dev: statSync(displacedFile).dev,
+      ino: statSync(displacedFile).ino,
+    })
+    releaseRead.resolve()
+
+    await expect(reconciliation).resolves.toEqual({ kind: 'full-scan' })
+    const current = await catalog.all()
+    expect(current).toMatchObject([{ id: 'rescanned-fresh' }])
+    expect(current.map(({ id }) => id)).not.toContain('staged-stale')
+    expect(readDirectory).toHaveBeenCalledTimes(2)
+    expect(readMetadata).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not publish a truncated real-file read when the transcript is appended during reconciliation', async () => {
+    const watchedRoot = mkdtempSync(join(tmpdir(), 'gooeypi-session-append-during-read-'))
+    realDirectories.push(watchedRoot)
+    const name = 'known.jsonl'
+    const filePath = join(watchedRoot, name)
+    writeFileSync(filePath, 'baseline')
+
+    const readDirectory = vi.fn(async (path: string): Promise<readonly SessionCatalogEntry[]> => readdirSync(path, { withFileTypes: true }))
+    const io: SessionCatalogIo = {
+      readDirectory,
+      canonicalize: async (path) => realpathSync(path),
+      inspect: async (path) => statSync(path),
+      inspectLink: async (path) => lstatSync(path),
+    }
+    const readStarted = deferred<void>()
+    const releaseRead = deferred<void>()
+    let reads = 0
+    const readMetadata = vi.fn(async (path: string) => {
+      reads += 1
+      const capturedLength = readFileSync(path, 'utf8').length
+      if (reads === 2) {
+        readStarted.resolve()
+        await releaseRead.promise
+      }
+      return { ...metadataFor(path, capturedLength), id: `content-v${capturedLength}` }
+    })
+    const catalog = new SessionMetadataCatalog(() => watchedRoot, null, 1, readMetadata, io)
+    await expect(catalog.all()).resolves.toMatchObject([{ id: 'content-v8' }])
+
+    appendFileSync(filePath, '-changed')
+    const reconciliation = catalog.reconcileKnownChanges([name])
+    await readStarted.promise
+    appendFileSync(filePath, '-after-read')
+    releaseRead.resolve()
+
+    await expect(reconciliation).resolves.toEqual({ kind: 'full-scan' })
+    const current = await catalog.all()
+    expect(current).toMatchObject([{ id: 'content-v27' }])
+    expect(current.map(({ id }) => id)).not.toContain('content-v16')
+    expect(readDirectory).toHaveBeenCalledTimes(2)
+    expect(readMetadata).toHaveBeenCalledTimes(3)
+  })
+
+  it('retains full-scan ordering semantics when a known candidate mtime changes', async () => {
+    const { catalog, files, entries } = fixture(2)
+    expect((await catalog.all()).map(({ id }) => id)).toEqual([
+      'session-00001-v0',
+      'session-00000-v0',
+    ])
+    Object.assign(files.get(sessionName(0))!, { mtimeMs: 10, size: 120, version: 1 })
+
+    await expect(catalog.reconcileKnownChanges([sessionName(0)])).resolves.toMatchObject({ kind: 'reconciled' })
+    expect((await catalog.all()).map(({ id }) => id)).toEqual([
+      'session-00000-v1',
+      'session-00001-v0',
+    ])
+    expect(entries).toHaveBeenCalledOnce()
+  })
+
+  it('serializes overlapping reconciles and falls back before an older read can publish', async () => {
+    const { catalog, files, entries } = fixture(1)
+    const readerHarness = catalog as unknown as {
+      readMetadata: (filePath: string, knownStat?: Stats) => Promise<SessionMetadata>
+    }
+    await catalog.all()
+    const originalReader = readerHarness.readMetadata
+    const gates: Array<ReturnType<typeof deferred<void>>> = []
+    const started: number[] = []
+    readerHarness.readMetadata = async (filePath, knownStat) => {
+      const version = files.get(sessionName(0))!.version
+      if (version === 0) return originalReader(filePath, knownStat)
+      const gate = deferred<void>()
+      gates.push(gate)
+      started.push(version)
+      await gate.promise
+      return metadataFor(filePath, version)
+    }
+
+    Object.assign(files.get(sessionName(0))!, { mtimeMs: 2, size: 101, version: 1 })
+    const first = catalog.reconcileKnownChanges([sessionName(0)])
+    await vi.waitFor(() => expect(started).toEqual([1]))
+
+    Object.assign(files.get(sessionName(0))!, { mtimeMs: 3, size: 102, version: 2 })
+    const second = catalog.reconcileKnownChanges([sessionName(0)])
+    const current = catalog.all()
+    expect(started).toEqual([1])
+
+    gates[0]!.resolve()
+    await vi.waitFor(() => expect(started).toEqual([1, 2]))
+    gates[1]!.resolve()
+
+    await expect(first).resolves.toEqual({ kind: 'full-scan' })
+    await expect(second).resolves.toEqual({ kind: 'full-scan' })
+    await expect(current).resolves.toMatchObject([{ id: 'session-00000-v2' }])
+    expect(entries).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/backend/sessions.test.ts
+++ b/tests/backend/sessions.test.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, chmodSync, createReadStream, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync, type Stats } from 'node:fs'
-import { stat } from 'node:fs/promises'
+import { lstat, readdir, realpath, stat } from 'node:fs/promises'
 import { createServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -177,9 +177,12 @@ describe('SessionService catalog scaling', () => {
     const names = Array.from({ length: 50_000 }, (_, index) => sessionName(index))
     const canonicalize = vi.fn(async (path: string) => path)
     const inspect = vi.fn(async (path: string) => {
+      if (path === root) {
+        return { isFile: () => false, isDirectory: () => true, mtimeMs: 1, size: 0, dev: 1, ino: 1 } as Stats
+      }
       const name = path.slice(path.lastIndexOf('/') + 1)
       const timestamp = Number.parseInt(name.slice(0, 8) + name.slice(9, 13), 16)
-      return { isFile: () => true, mtimeMs: timestamp, size: 100 } as Stats
+      return { isFile: () => true, isDirectory: () => false, mtimeMs: timestamp, size: 100, dev: 1, ino: timestamp + 2 } as Stats
     })
     const io: SessionCatalogIo = {
       readDirectory: vi.fn(async () => names.map((name) => ({ name }))),
@@ -206,7 +209,7 @@ describe('SessionService catalog scaling', () => {
     const selectedIds = [49_999, 49_998, 49_997].map((value) => sessionName(value).slice(0, -'.jsonl'.length))
     expect(records.map((record) => record.id).sort()).toEqual(selectedIds.sort())
     expect(canonicalize).toHaveBeenCalledTimes(1 + maxSessionFiles)
-    expect(inspect).toHaveBeenCalledTimes(2 * maxSessionFiles)
+    expect(inspect).toHaveBeenCalledTimes(1 + 2 * maxSessionFiles)
     expect(readMetadata).toHaveBeenCalledTimes(maxSessionFiles)
     expect(inspect.mock.calls.flat().join(' ')).not.toContain(sessionName(0))
   })
@@ -222,9 +225,12 @@ describe('SessionService catalog scaling', () => {
       readDirectory: vi.fn(async () => [...identities.keys()].map((name) => ({ name }))),
       canonicalize,
       inspect: vi.fn(async (path: string) => {
+        if (path === root) {
+          return { isFile: () => false, isDirectory: () => true, mtimeMs: 1, size: 0, dev: 1, ino: 1 } as Stats
+        }
         const name = path.slice(path.lastIndexOf('/') + 1)
         const identity = identities.get(name) ?? { dev: 1, ino: 99 }
-        return { isFile: () => true, mtimeMs: 1, size: 100, dev: identity.dev, ino: identity.ino } as Stats
+        return { isFile: () => true, isDirectory: () => false, mtimeMs: 1, size: 100, dev: identity.dev, ino: identity.ino } as Stats
       }),
     }
     const catalog = new SessionMetadataCatalog(
@@ -379,6 +385,27 @@ describe('SessionService user-message ordering', () => {
 })
 
 describe('SessionMetadataCatalog live synchronization', () => {
+  it('keeps live overlays when a known-file reconcile refreshes JSONL metadata', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prime-work-live-reconcile-')); dirs.push(dir)
+    const root = join(dir, 'sessions'); mkdirSync(root)
+    const project = join(dir, 'project'); mkdirSync(project)
+    const file = join(root, 'live.jsonl')
+    writeSession(file, project, 'live-v0')
+    const executable = join(dir, 'prime-agent.cjs')
+    writeFileSync(executable, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ sessions: [{ sessionFile: ${JSON.stringify(file)}, isStreaming: true }] }))
+`)
+    chmodSync(executable, 0o755)
+    const reader = createSessionMetadataReader()
+    const catalog = new SessionMetadataCatalog(() => root, executable, 20, reader)
+    expect(await catalog.all()).toMatchObject([{ id: 'live-v0', status: 'running' }])
+
+    writeSession(file, project, 'live-v1', '2025-02-01T00:00:00.000Z')
+    await expect(catalog.reconcileKnownChanges(['live.jsonl'])).resolves.toMatchObject({ kind: 'reconciled' })
+
+    expect(await catalog.all()).toMatchObject([{ id: 'live-v1', status: 'running' }])
+  })
+
   it('does not join an in-flight scan owned by the previous executable', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'prime-work-scan-executable-race-')); dirs.push(dir)
     const root = join(dir, 'sessions'); mkdirSync(root)
@@ -547,6 +574,79 @@ process.exit(0)
 
 
 describe('SessionService live changes', () => {
+  it('reconciles a known watched file without enumerating the session directory again', async () => {
+    const readDirectory = vi.fn(async (path: string) => readdir(path, { withFileTypes: true }))
+    const canonicalize = vi.fn(async (path: string): Promise<string> => realpath(path))
+    const inspect = vi.fn(async (path: string): Promise<Stats> => stat(path))
+    const inspectLink = vi.fn(async (path: string): Promise<Stats> => lstat(path))
+    const watchDirectory: NonNullable<SessionServiceOptions['watchDirectory']> = () => {
+      const watcher = { close: vi.fn(), on: () => watcher }
+      return watcher
+    }
+    const { root, project, service } = setup(undefined, {
+      catalogIo: { readDirectory, canonicalize, inspect, inspectLink },
+      watchDirectory,
+    })
+    const file = join(root, 'known.jsonl')
+    writeSession(file, project, 'known-v0')
+    expect(await service.list()).toMatchObject([{ id: 'known-v0' }])
+    const enumerationCount = readDirectory.mock.calls.length
+    const canonicalizationCount = canonicalize.mock.calls.length
+
+    const events: Array<{ filePath?: string }> = []
+    const unsubscribe = service.onDidChange((event) => events.push(event))
+    try {
+      writeSession(file, project, 'known-v1', '2025-02-01T00:00:00.000Z')
+      const watcherHarness = service as unknown as { queueSessionChange(filename: string): void }
+      watcherHarness.queueSessionChange('known.jsonl')
+      await waitUntil(() => events.some((event) => event.filePath === realpathSync(file)), 4_000)
+
+      expect(await service.list()).toMatchObject([{ id: 'known-v1' }])
+      expect(readDirectory).toHaveBeenCalledTimes(enumerationCount)
+      expect(canonicalize).toHaveBeenCalledTimes(canonicalizationCount + 2)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('falls back to a full scan after a watcher error loses the changed file name', async () => {
+    const readDirectory = vi.fn(async (path: string) => readdir(path, { withFileTypes: true }))
+    let reportWatchError: ((error: Error) => void) | undefined
+    const watchDirectory: NonNullable<SessionServiceOptions['watchDirectory']> = () => {
+      const watcher = {
+        close: vi.fn(),
+        on: (_event: 'error', listener: (error: Error) => void) => {
+          reportWatchError = listener
+          return watcher
+        },
+      }
+      return watcher
+    }
+    const { root, project, service } = setup(undefined, {
+      catalogIo: {
+        readDirectory,
+        canonicalize: async (path) => realpath(path),
+        inspect: async (path) => stat(path),
+        inspectLink: async (path) => lstat(path),
+      },
+      watchDirectory,
+    })
+    writeSession(join(root, 'known.jsonl'), project, 'known')
+    await service.list()
+    expect(readDirectory).toHaveBeenCalledOnce()
+
+    const events: Array<{ filePath?: string }> = []
+    const unsubscribe = service.onDidChange((event) => events.push(event))
+    try {
+      reportWatchError?.(new Error('watch overflow'))
+      await waitUntil(() => events.some((event) => event.filePath === undefined), 4_000)
+      await service.list()
+      expect(readDirectory).toHaveBeenCalledTimes(2)
+    } finally {
+      unsubscribe()
+    }
+  })
+
   it('installs a one-level watcher and resolves bucketed session changes', async () => {
     const watched = new Map<string, (eventType: string, filename: string | Buffer | null) => void>()
     const { root, project, service } = setup(undefined, {


### PR DESCRIPTION
## Summary

- reconcile known existing session-file changes without enumerating the full catalog
- retain a versioned prepared snapshot keyed by watched relative name and canonical path
- reuse untouched metadata object identities and preserve ordering/live overlays
- fall back to the established full scan for unknown/create/delete/rename/force/watcher/admission/identity/containment cases
- validate root, bucket, intermediate, and complete leaf snapshots before publication

## Root cause

The watcher already batched exact changed names, but every batch invalidated and rebuilt the full live catalog. Appending to one transcript repeatedly enumerated, sorted, canonicalized, and stated up to 5,000 files despite an existing metadata cache.

The initial fast-path implementation detected an append that raced with metadata parsing but still prepared the staged parse result. Avoiding the metadata cache was insufficient because the prepared snapshot itself could publish stale or truncated metadata.

## Design and measured bound

After a 5,000-file baseline, one stable known change performs:

- 0 directory enumerations
- 2 leaf canonical checks
- bounded leaf/ancestor lstat/stat checks
- 1 metadata read

Fast-path filesystem discovery and validation are O(changed paths × directory depth), independent of catalog size. Reading and parsing changed transcript content remains O(changed file size).

Each prepared leaf snapshot includes identity, size, mtime, ctime, and mode. The snapshot is compared with the post-read regular-file metadata; any instability discards the staged parse and returns full-scan. Reconciles remain serialized/versioned, and identity, containment, or ancestry uncertainty also returns full-scan.

## Regression coverage

A deterministic real-filesystem test pauses a changed transcript read after capturing its content, appends more JSONL bytes while that read remains in flight, and then releases it. The fast path must reject the truncated staged result, perform the established full scan, and publish only the complete transcript metadata.

Existing real-filesystem root, bucket, symlink, hard-link, identity, containment, ordering, live-overlay, and overlapping-reconcile coverage remains intact.

## Verification

Exact local head 6f5565511f5f7414a4c2d29d400570a24fdc716f on current main bce2d6e:

- focused reconciliation: 14/14 passed
- backend session/transcript set: 103/103 passed
- full suite with bounded workers: 1,322 passed, 1 expected skip (132 files)
- typecheck: passed
- repository check: passed (existing unrelated Biome diagnostics only)
- production build: passed
- release bundle-size gate: passed; main bundle 655,016 bytes against the unchanged 655,360-byte budget
- diff check: passed
- independent implementation and bundle-fix delta reviews: READY, no code findings

## Stack

PR #49 has merged. This PR is one issue-specific commit on current main and changes only the five intended session-catalog implementation/test files.

Fixes #59
