### PR TITLE
Fix composer caret alignment across scrollbar overflow

### DIFF
--- a/src/components/Composer.tsx
+++ b/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { ArrowUp, AtSign, Brain, Check, ChevronDown, Clock3, Command, Edit3, FolderGit2, Gauge, ImageIcon, LoaderCircle, MessageCirclePlus, Mic, Plus, Square, SquareTerminal, Trash2, X, Zap } from 'lucide-react'
 import { memo, useEffect, useId, useMemo, useRef, useState } from 'react'
-import type { CSSProperties, ReactNode } from 'react'
+import type { CSSProperties } from 'react'
 import type {
   BrowserAnnotation,
   GitWorktree,
@@ -21,7 +21,7 @@ import type {
   VoiceTranscriptionProvider,
 } from '@/types/api'
 import { appendAnnotationsToPrompt } from '@/lib/browser-annotations'
-import { appendCapabilityRouting, findCapabilityMentions } from '@/lib/capability-mentions'
+import { appendCapabilityRouting } from '@/lib/capability-mentions'
 import { appendTerminalContextToPrompt } from '@/lib/terminal-context'
 import { appendSessionRouting, findSessionMentions } from '@/lib/session-mentions'
 import { takeComposerDraft } from '@/lib/composer-draft'
@@ -192,7 +192,6 @@ export const Composer = memo(function Composer({
   const worktreeMenuId = useId()
   const worktreeMenuRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const mentionHighlightRef = useRef<HTMLDivElement>(null)
   const acceptedMentionRef = useRef<{ start: number; text: string } | null>(null)
   const submittingRef = useRef(false)
   const pendingImagesRef = useRef(0)
@@ -201,23 +200,6 @@ export const Composer = memo(function Composer({
   annotationsRef.current = annotations
   const mountedRef = useRef(true)
   const enabledSkills = useMemo(() => skills.filter((skill) => skill.enabled), [skills])
-  const capabilityMentions = useMemo(() => findCapabilityMentions(value, enabledSkills), [enabledSkills, value])
-  const sessionMentions = useMemo(() => findSessionMentions(value, sessions, sessionReferenceIds), [sessionReferenceIds, sessions, value])
-  const highlightedValue = useMemo(() => {
-    const mentions = [...sessionMentions, ...capabilityMentions]
-      .sort((left, right) => left.start - right.start)
-      .filter((mention, index, all) => index === 0 || mention.start >= all[index - 1].end)
-    if (!mentions.length) return value
-    const parts: ReactNode[] = []
-    let cursor = 0
-    for (const mention of mentions) {
-      if (mention.start > cursor) parts.push(value.slice(cursor, mention.start))
-      parts.push(<mark key={`${mention.start}:${mention.end}`}>{mention.text}</mark>)
-      cursor = mention.end
-    }
-    if (cursor < value.length) parts.push(value.slice(cursor))
-    return parts
-  }, [capabilityMentions, sessionMentions, value])
 
   useEffect(() => {
     const mentionMatch = /(?:^|\s)@([^@\n]*)$/.exec(value)
@@ -550,10 +532,6 @@ export const Composer = memo(function Composer({
       ) : null}
       <div className={`composer ${busy || submitting ? 'composer--busy' : ''}`}>
         <div className="composer-input">
-          <div ref={mentionHighlightRef} className="composer-input__highlight" aria-hidden="true">
-            {highlightedValue}
-            {value.endsWith('\n') ? '\n ' : null}
-          </div>
           <textarea
             ref={textareaRef}
             value={value}
@@ -567,11 +545,6 @@ export const Composer = memo(function Composer({
             aria-controls={menu ? menuId : undefined}
             aria-activedescendant={menu && suggestions.length ? `${menuId}-option-${activeSuggestion}` : undefined}
             onChange={(event) => setValue(event.target.value)}
-            onScroll={(event) => {
-              if (!mentionHighlightRef.current) return
-              mentionHighlightRef.current.scrollTop = event.currentTarget.scrollTop
-              mentionHighlightRef.current.scrollLeft = event.currentTarget.scrollLeft
-            }}
             onPaste={(event) => {
               const files = [...event.clipboardData.items]
                 .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))

--- a/src/styles/composer.css
+++ b/src/styles/composer.css
@@ -19,11 +19,10 @@
 .composer:focus-within { border-color: color-mix(in srgb, var(--border-strong) 65%, var(--focus)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--focus) 30%, transparent); }
 .composer--busy { border-color: color-mix(in srgb, var(--prime) 33%, var(--border-strong)); }
 .composer-input { position: relative; width: 100%; min-height: 55px; max-height: 150px; flex: 1; }
-.composer-input > textarea, .composer-input__highlight { width: 100%; height: 100%; min-height: 55px; max-height: 150px; padding: 6px 9px; border: 0; font: inherit; font-size: 14px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: break-word; }
-.composer-input > textarea { position: relative; z-index: 1; display: block; resize: none; outline: 0; color: transparent; background: transparent; caret-color: var(--text); -webkit-text-fill-color: transparent; }
-.composer-input > textarea::placeholder { color: var(--text-tertiary); -webkit-text-fill-color: var(--text-tertiary); }
-.composer-input__highlight { position: absolute; z-index: 0; inset: 0; overflow: hidden; color: var(--text); pointer-events: none; }
-.composer-input__highlight mark { padding: 0; border: 0; border-radius: 0; color: var(--prime); background: transparent; font: inherit; letter-spacing: inherit; }
+/* The native control is the sole text renderer so its glyphs, wrapping, selection,
+   caret, and platform scrollbar always share one authoritative content box. */
+.composer-input > textarea { width: 100%; height: 100%; min-height: 55px; max-height: 150px; display: block; padding: 6px 9px; border: 0; resize: none; outline: 0; color: var(--text); background: transparent; caret-color: var(--text); font: inherit; font-size: 14px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: break-word; }
+.composer-input > textarea::placeholder { color: var(--text-tertiary); }
 .composer-attachments { display: flex; align-items: center; gap: 6px; padding: 1px 6px 7px; overflow-x: auto; }
 .composer-attachment { max-width: 190px; height: 34px; display: flex; align-items: center; gap: 5px; flex: 0 0 auto; padding: 3px 4px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-subtle); }
 .composer-attachment > img { width: 26px; height: 26px; flex: 0 0 auto; border-radius: 4px; object-fit: cover; }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1170,6 +1170,64 @@ test.describe('Prime Work desktop smoke', () => {
     await expect(page.getByRole('combobox', { name: 'Message Prime' })).toHaveValue('')
   })
 
+  test('keeps wrapped editing native and aligned through classic scrollbar overflow', async () => {
+    const composer = page.getByRole('combobox', { name: 'Message Prime' })
+    await page.addStyleTag({ content: `
+      .composer-input > textarea { overflow-y: scroll !important; }
+      .composer-input > textarea::-webkit-scrollbar { width: 28px; }
+    ` })
+
+    await composer.fill('@Ownership')
+    const reference = page.getByRole('option', { name: /@Ownership peer fixture/ })
+    await expect(reference).toBeVisible()
+    await expect(composer).toHaveAttribute('aria-autocomplete', 'list')
+    await reference.click()
+
+    const longToken = 'unbroken-token-'.repeat(18)
+    const draft = `@Ownership peer fixture\nFirst wrapped line ${'with words '.repeat(22)}\nEDITME ${longToken}\n${'final line '.repeat(30)}`
+    await composer.fill(draft)
+    const editStart = draft.indexOf('EDITME')
+    await composer.evaluate((element, start) => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.focus()
+      textarea.setSelectionRange(start, start + 'EDITME'.length)
+    }, editStart)
+    await composer.pressSequentially('replacement')
+    await expect(composer).toHaveValue(draft.replace('EDITME', 'replacement'))
+
+    const layout = await composer.evaluate((element) => {
+      const textarea = element as HTMLTextAreaElement
+      textarea.scrollTop = textarea.scrollHeight
+      textarea.dispatchEvent(new Event('scroll'))
+      const style = getComputedStyle(textarea)
+      return {
+        hasVerticalOverflow: textarea.scrollHeight > textarea.clientHeight,
+        scrollbarWidth: textarea.offsetWidth - textarea.clientWidth,
+        scrollTop: textarea.scrollTop,
+        color: style.color,
+        textFillColor: style.webkitTextFillColor,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+        mirrorCount: textarea.parentElement?.querySelectorAll('.composer-input__highlight').length ?? -1,
+      }
+    })
+    expect(layout.hasVerticalOverflow).toBe(true)
+    expect(layout.scrollbarWidth).toBeGreaterThanOrEqual(24)
+    expect(layout.scrollTop).toBeGreaterThan(0)
+    expect(layout.selectionStart).toBe(layout.selectionEnd)
+    expect(layout.color).not.toBe('rgba(0, 0, 0, 0)')
+    expect(layout.textFillColor).not.toBe('rgba(0, 0, 0, 0)')
+    expect(layout.mirrorCount).toBe(0)
+
+    await page.emulateMedia({ forcedColors: 'active' })
+    const forcedColorText = await composer.evaluate((element) => {
+      const style = getComputedStyle(element)
+      return { color: style.color, textFillColor: style.webkitTextFillColor }
+    })
+    expect(forcedColorText.color).not.toBe('rgba(0, 0, 0, 0)')
+    expect(forcedColorText.textFillColor).not.toBe('rgba(0, 0, 0, 0)')
+  })
+
   test('copies a session id and routes an @session mention without exposing its UUID block', async () => {
     await page.evaluate(() => {
       const target = window as Window & { __copiedSessionId?: string }
@@ -1194,27 +1252,7 @@ test.describe('Prime Work desktop smoke', () => {
       return { start: textarea.selectionStart, end: textarea.selectionEnd, length: textarea.value.length }
     })
     expect(caret).toEqual({ start: caret.length, end: caret.length, length: caret.length })
-    const mentionStyles = await page.evaluate(() => {
-      const textarea = document.querySelector('.composer-input textarea')
-      const mark = document.querySelector('.composer-input__highlight mark')
-      if (!textarea || !mark) return null
-      const input = getComputedStyle(textarea)
-      const highlight = getComputedStyle(mark)
-      return {
-        inputFont: input.font,
-        highlightFont: highlight.font,
-        inputLetterSpacing: input.letterSpacing,
-        highlightLetterSpacing: highlight.letterSpacing,
-        background: highlight.backgroundColor,
-        border: highlight.borderTopWidth,
-      }
-    })
-    expect(mentionStyles).toMatchObject({
-      inputFont: mentionStyles?.highlightFont,
-      inputLetterSpacing: mentionStyles?.highlightLetterSpacing,
-      background: 'rgba(0, 0, 0, 0)',
-      border: '0px',
-    })
+    await expect(composer).toHaveAttribute('aria-expanded', 'false')
     await composer.pressSequentially('about ownership')
     await expect(composer).toHaveValue('Coordinate with @Ownership peer fixture about ownership')
     await composer.press('Enter')


### PR DESCRIPTION
Fixes #79

## Summary
- make the native textarea the composer’s sole text/layout renderer
- remove mirrored mention markup and scroll synchronization that could wrap against a different content width when classic scrollbars appear
- retain accessible combobox mention suggestions, accepted-mention routing, keyboard editing, and native selection behavior
- add a real Electron/Chromium regression covering wrapped text, classic scrollbar overflow, selection replacement, session mentions, long tokens, newlines, scrolling, and forced-colors text visibility

## Test plan
- `npm test -- tests/frontend/composer-annotations.test.tsx`
- `npm run typecheck`
- `npm run check`
- `npm run build`
- `npx playwright test tests/e2e/app.spec.ts --grep "wrapped editing native|routes an @session mention" --retries=0`

## Risk review
- Accepted mentions no longer receive inline accent coloring while editing; suggestion semantics and routing remain unchanged.
- Using one native textarea removes cross-platform scrollbar-width synchronization and improves IME/selection behavior without custom measurement.
- Forced-colors visibility is exercised in Chromium; classic scrollbar width is forced in the regression to cover non-overlay scrollbar platforms.