### PR TITLE
test: make collaboration early-wake coverage deterministic

### DIFF
--- a/electron/main/collaboration/agent-bridge.ts
+++ b/electron/main/collaboration/agent-bridge.ts
@@ -20,12 +20,22 @@ const WAIT_TRANSCRIPT_POLL_MS = 1_000
 const WAIT_RUNTIME_POLL_MS = 250
 const MAX_ACTIVE_WAITS_PER_TOKEN = 2
 
-async function delayUntil(targetTime: number): Promise<void> {
+interface CollaborationWaitClock {
+  now(): number
+  setTimeout(callback: () => void, delayMs: number): { unref(): void }
+}
+
+const nativeWaitClock: CollaborationWaitClock = {
+  now: () => Date.now(),
+  setTimeout: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+}
+
+async function delayUntil(targetTime: number, clock: CollaborationWaitClock): Promise<void> {
   while (true) {
-    const remaining = targetTime - Date.now()
+    const remaining = targetTime - clock.now()
     if (remaining <= 0) return
     await new Promise<void>((resolveDelay) => {
-      const timer = setTimeout(resolveDelay, remaining)
+      const timer = clock.setTimeout(resolveDelay, remaining)
       timer.unref()
     })
   }
@@ -49,6 +59,7 @@ export interface AgentCollaborationBridgeOptions {
   catalogs: Record<HarnessId, ModelCatalogProvider>
   disabledProviders: Record<HarnessId, () => ReadonlySet<string>>
   disabledModels: Record<HarnessId, () => ReadonlySet<string>>
+  waitClock?: CollaborationWaitClock
 }
 
 interface CollaborationMessage {
@@ -142,8 +153,12 @@ export class AgentCollaborationBridge extends CapabilityBridge {
   private readonly activeWaitTargets = new Set<string>()
   private readonly activeCreations = new Set<string>()
   private readonly pendingRuntimeTokens = new Map<string, string>()
+  private readonly waitClock: CollaborationWaitClock
 
-  constructor(private readonly options: AgentCollaborationBridgeOptions) { super() }
+  constructor(private readonly options: AgentCollaborationBridgeOptions) {
+    super()
+    this.waitClock = options.waitClock ?? nativeWaitClock
+  }
 
   protected environmentEntries(url: string, token: string): NodeJS.ProcessEnv {
     return {
@@ -422,10 +437,10 @@ export class AgentCollaborationBridge extends CapabilityBridge {
   private async wait(target: CollaborationTarget, rawCursor: unknown, rawTimeout: unknown): Promise<CollaborationSnapshot & { timed_out: boolean }> {
     const afterCursor = rawCursor === undefined ? undefined : requireString(rawCursor, 'after_cursor', { min: 1, max: 128, trim: true })
     const timeoutMs = rawTimeout === undefined ? 15_000 : requireInteger(rawTimeout, 'timeout_ms', 0, MAX_WAIT_MS)
-    const startedAt = Date.now()
+    const startedAt = this.waitClock.now()
     const deadline = startedAt + timeoutMs
     let snapshot = await this.snapshot(target)
-    while (Date.now() < deadline) {
+    while (this.waitClock.now() < deadline) {
       const runtime = target.manager.getForSession(target.session.filePath)
       const idle = !runtime || (!runtime.isStreaming && !runtime.isCompacting && !runtime.sessionActions?.active && (runtime.sessionActions?.queuedCount ?? 0) === 0)
       if (idle && (afterCursor === undefined || snapshot.cursor !== afterCursor)) return { ...snapshot, timed_out: false }
@@ -433,8 +448,8 @@ export class AgentCollaborationBridge extends CapabilityBridge {
       // reads resume at a bounded cadence once the target is idle/offline.
       // Re-arm an early timer wake until the intended poll instant so a short
       // wait cannot perform multiple transcript reads at its deadline.
-      const nextPollAt = Math.min(deadline, Date.now() + (idle ? WAIT_TRANSCRIPT_POLL_MS : WAIT_RUNTIME_POLL_MS))
-      await delayUntil(nextPollAt)
+      const nextPollAt = Math.min(deadline, this.waitClock.now() + (idle ? WAIT_TRANSCRIPT_POLL_MS : WAIT_RUNTIME_POLL_MS))
+      await delayUntil(nextPollAt, this.waitClock)
       if (idle) {
         snapshot = await this.snapshot(target)
         if (afterCursor === undefined || snapshot.cursor !== afterCursor) return { ...snapshot, timed_out: false }

--- a/tests/backend/agent-collaboration-bridge.test.ts
+++ b/tests/backend/agent-collaboration-bridge.test.ts
@@ -67,7 +67,53 @@ const defaultTargetTranscript: TranscriptMessage[] = [
   { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'The endpoint is ready.' }] },
 ]
 
-async function fixture(live = true, targetTranscript: TranscriptMessage[] = defaultTargetTranscript) {
+interface ScheduledFakeTimer {
+  callback: () => void
+  requestedAt: number
+  delayMs: number
+  dueAt: number
+  unref: () => void
+}
+
+class FakeCollaborationWaitClock {
+  private readonly pending: ScheduledFakeTimer[] = []
+  private readonly waiters: Array<(timer: ScheduledFakeTimer) => void> = []
+
+  constructor(private currentTime = 10_000) {}
+
+  readonly now = (): number => this.currentTime
+
+  readonly setTimeout = (callback: () => void, delayMs: number): { unref(): void } => {
+    const timer: ScheduledFakeTimer = {
+      callback,
+      requestedAt: this.currentTime,
+      delayMs,
+      dueAt: this.currentTime + delayMs,
+      unref: vi.fn(),
+    }
+    const waiter = this.waiters.shift()
+    if (waiter) waiter(timer)
+    else this.pending.push(timer)
+    return { unref: timer.unref }
+  }
+
+  takeNextTimer(): Promise<ScheduledFakeTimer> {
+    const timer = this.pending.shift()
+    if (timer) return Promise.resolve(timer)
+    return new Promise((resolveTimer) => this.waiters.push(resolveTimer))
+  }
+
+  fireAt(timer: ScheduledFakeTimer, timestamp: number): void {
+    this.currentTime = timestamp
+    timer.callback()
+  }
+}
+
+async function fixture(
+  live = true,
+  targetTranscript: TranscriptMessage[] = defaultTargetTranscript,
+  waitClock?: FakeCollaborationWaitClock,
+) {
   const records = [source, target, foreign, child, archived]
   const primeSessions = service(records, {
     [target.filePath]: targetTranscript,
@@ -108,6 +154,7 @@ async function fixture(live = true, targetTranscript: TranscriptMessage[] = defa
     } as unknown as ConstructorParameters<typeof AgentCollaborationBridge>[0]['catalogs'],
     disabledProviders: { prime: () => new Set(['hidden']), omp: () => new Set(), pi: () => new Set() },
     disabledModels: { prime: () => new Set(['openai-codex/desktop-hidden']), omp: () => new Set(), pi: () => new Set() },
+    ...(waitClock ? { waitClock } : {}),
   })
   await bridge.start()
   bridges.push(bridge)
@@ -341,23 +388,29 @@ describe('AgentCollaborationBridge', () => {
   })
 
   it('re-arms an early timeout wake without polling the transcript early', async () => {
-    const { call, primeSessions } = await fixture()
+    const clock = new FakeCollaborationWaitClock()
+    const { call, primeSessions } = await fixture(true, defaultTargetTranscript, clock)
     const read = await call('read', { target_session_id: target.id })
     const cursor = (read.body.result as Record<string, unknown>).cursor
     const readsBefore = primeSessions.read.mock.calls.length
-    const nativeSetTimeout = globalThis.setTimeout
-    const timer = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
-      const requested = Number(delay ?? 0)
-      return nativeSetTimeout(callback, requested > 25 && requested <= 150 ? requested - 25 : requested, ...args)
-    }) as typeof setTimeout)
+    const waiting = call('wait', { target_session_id: target.id, after_cursor: cursor, timeout_ms: 150 })
 
-    try {
-      const completed = await call('wait', { target_session_id: target.id, after_cursor: cursor, timeout_ms: 150 })
-      expect(completed.body.result).toMatchObject({ timed_out: true })
-      expect(primeSessions.read.mock.calls.length - readsBefore).toBeLessThanOrEqual(2)
-    } finally {
-      timer.mockRestore()
-    }
+    const firstTimer = await clock.takeNextTimer()
+    expect(firstTimer).toMatchObject({ requestedAt: 10_000, delayMs: 150, dueAt: 10_150 })
+    expect(firstTimer.unref).toHaveBeenCalledOnce()
+    expect(primeSessions.read.mock.calls.length - readsBefore).toBe(1)
+
+    clock.fireAt(firstTimer, firstTimer.dueAt - 25)
+    const replacementTimer = await clock.takeNextTimer()
+    expect(replacementTimer).toMatchObject({ requestedAt: 10_125, delayMs: 25, dueAt: 10_150 })
+    expect(replacementTimer.unref).toHaveBeenCalledOnce()
+    expect(primeSessions.read.mock.calls.length - readsBefore).toBe(1)
+
+    clock.fireAt(replacementTimer, replacementTimer.dueAt)
+    const completed = await waiting
+    expect(completed.body.result).toMatchObject({ timed_out: true })
+    expect(clock.now()).toBe(10_150)
+    expect(primeSessions.read.mock.calls.length - readsBefore).toBe(2)
   })
 
   it('reports a transcript change found by the final deadline snapshot', async () => {
@@ -365,7 +418,8 @@ describe('AgentCollaborationBridge', () => {
       ...defaultTargetTranscript,
       { id: 'a2', role: 'assistant', parts: [{ type: 'text', text: 'The deadline update is ready.' }] },
     ]
-    const { call, primeSessions } = await fixture()
+    const clock = new FakeCollaborationWaitClock()
+    const { call, primeSessions } = await fixture(true, defaultTargetTranscript, clock)
     let reads = 0
     primeSessions.read.mockImplementation(async () => {
       reads += 1
@@ -374,12 +428,19 @@ describe('AgentCollaborationBridge', () => {
     const read = await call('read', { target_session_id: target.id })
     const cursor = (read.body.result as Record<string, unknown>).cursor
 
-    const completed = await call('wait', { target_session_id: target.id, after_cursor: cursor, timeout_ms: 50 })
+    const waiting = call('wait', { target_session_id: target.id, after_cursor: cursor, timeout_ms: 50 })
+    const deadlineTimer = await clock.takeNextTimer()
+    expect(deadlineTimer).toMatchObject({ requestedAt: 10_000, delayMs: 50, dueAt: 10_050 })
+    expect(deadlineTimer.unref).toHaveBeenCalledOnce()
+    clock.fireAt(deadlineTimer, deadlineTimer.dueAt)
+    const completed = await waiting
 
     expect(completed.body.result).toMatchObject({ timed_out: false })
     expect((completed.body.result as Record<string, unknown>).messages).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: 'a2', text: 'The deadline update is ready.' }),
     ]))
+    expect(clock.now()).toBe(10_050)
+    expect(reads).toBe(3)
   })
 
   it('wakes an offline target while rejecting missing source scope and invalid tokens', async () => {


### PR DESCRIPTION
## Summary

- inject a collaboration-wait-only clock/timer seam with native production defaults
- replace the global timer spy and wall-clock delay with a deterministic fake clock
- verify early-wake re-arming, timer `unref()` ownership, no premature transcript read, and exact-deadline snapshots

## Root cause

The regression added in #39 correctly exercised the early-wake path, but it shortened a real process-global timer while production still read `Date.now()`. Its result therefore depended on host clock progression and scheduler timing.

## Design

`AgentCollaborationBridge` accepts an optional internal wait clock exposing only `now()` and timer creation. Production falls back to `Date.now()` and Node's native `setTimeout`; the existing delay loop continues to call `unref()` on every timer handle.

The integration fixture injects a manually driven fake clock. The test delivers a callback 25 ms before its due time, observes an exact 25 ms replacement timer, proves the transcript is not read during that early wake, then advances to the deadline and verifies the final snapshot. The last-moment transcript-change test now uses the same deterministic clock.

This does not change the collaboration protocol, timeout bounds, polling cadence, cursor semantics, or production scheduling behavior.

## Verification

- focused collaboration bridge suite: 13 passed
- complete Vitest suite: 1,305 passed, 1 skipped
- `npm run typecheck`
- `npm run check`
- `npm run build`
- `npm run release:bundle-size`
- `git diff --check`
- independent review of exact head `b1fbc27cfea7875b04520b313165979a224fa09d`: ready

## Review source

This implements the non-blocking follow-up requested by `@am-will` while approving #39: https://github.com/am-will/gooey-pi/pull/39#issuecomment-5303456981

Fixes #83
