### PR TITLE
fix(ci): preserve strict latest-main validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'push' && format('push-{0}', github.sha) || format('dispatch-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,5 +1,29 @@
 # Validation status
 
+## Protected `main` validation contract
+
+The repository's `main` branch protection must require pull requests and require status checks to pass with **Require branches to be up to date before merging** enabled (`required_status_checks.strict: true`). This strict latest-main requirement prevents a PR from merging on a newer base than the integration state validated by CI.
+
+The required checks are exactly the six normal pull-request gates:
+
+- `quality`
+- `hermetic-e2e`
+- `windows-state-migration`
+- `packaging-smoke (macos-14, mac, arm64, --config.mac.identity=null)`
+- `packaging-smoke (ubuntu-22.04, linux, x64)`
+- `packaging-smoke (windows-2022, win, x64)`
+
+Do not require `local-qa-package`: it is manual local QA, runs only through `workflow_dispatch`, and is intentionally excluded from pull-request validation.
+
+GitHub merge queues are not available to this public repository while it is owned by a personal account. Consequently, `merge_group` or a required merge queue cannot enforce this policy here; strict up-to-date branch protection is the supported latest-main control. If the repository moves to an organization, merge-queue support should be designed and tested separately before enabling it.
+
+An authorized maintainer can verify the active legacy branch protection and exact required-context set with:
+
+```sh
+gh api repos/am-will/gooey-pi/branches/main/protection \
+  --jq '{strict: .required_status_checks.strict, contexts: .required_status_checks.contexts, reviews: .required_pull_request_reviews}'
+```
+
 Last full local validation: 2026-08-06 on Apple Silicon macOS.
 
 | Gate | Result |

--- a/tests/release-scripts.test.ts
+++ b/tests/release-scripts.test.ts
@@ -649,10 +649,19 @@ else if (JSON.stringify(args) === ${JSON.stringify(JSON.stringify(expectedInstal
     expect(ciSteps.filter((step) => step.secretLines.length > 0)).toEqual([])
   })
 
+  test('cancels superseded PR runs without cancelling validation for pushed SHAs', () => {
+    const workflow = load(readFileSync('.github/workflows/ci.yml', 'utf8')) as {
+      concurrency: { group: string; 'cancel-in-progress': string }
+    }
+    expect(workflow.concurrency.group).toBe(
+      "ci-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'push' && format('push-{0}', github.sha) || format('dispatch-{0}', github.run_id) }}",
+    )
+    expect(workflow.concurrency['cancel-in-progress']).toBe("${{ github.event_name == 'pull_request' }}")
+  })
+
   test('gates packaging regressions on every pull request', () => {
     const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
     expect(ciWorkflow).toMatch(/on:\n {2}push:\n {4}branches:\n {6}- main/)
-    expect(ciWorkflow).toContain('cancel-in-progress: true')
     expect(ciWorkflow).toMatch(/packaging-smoke:\n {4}if: github\.event_name == 'pull_request'/)
     for (const runner of ['macos-14', 'ubuntu-22.04', 'windows-2022']) expect(ciWorkflow).toContain(`runner: ${runner}`)
     expect(ciWorkflow).toContain('node node_modules/electron-builder/cli.js --dir')


### PR DESCRIPTION
## Summary
- cancel superseded CI runs per pull request while preserving every pushed SHA validation
- give manual dispatches unique non-cancelling groups
- structurally test the event-aware concurrency contract without coupling to job counts
- document the exact strict branch-protection checks, manual-QA exclusion, personal-account merge-queue limitation, and verification command

## Admin setting evidence
Current repository API output (captured before opening this PR):

```json
{"default_branch":"main","owner_type":"User"}
{"contexts":["quality","hermetic-e2e","windows-state-migration","packaging-smoke (macos-14, mac, arm64, --config.mac.identity=null)","packaging-smoke (ubuntu-22.04, linux, x64)","packaging-smoke (windows-2022, win, x64)"],"enforce_admins":true,"restrictions":null,"reviews":true,"strict":true}
```

This confirms strict latest-main checks, pull-request review protection, admin enforcement, and the exact six required CI contexts. The `User` owner type also confirms that a merge queue is not the applicable control for this public personal-account repository.

Verification command:

```sh
gh api repos/am-will/gooey-pi/branches/main/protection \
  --jq '{strict: .required_status_checks.strict, contexts: .required_status_checks.contexts, reviews: .required_pull_request_reviews}'
```

## Validation
- `npm exec -- vitest run tests/release-scripts.test.ts` (84 passed)
- `npm run typecheck`
- `npm run check` (passes; existing 1 warning and 2 informational diagnostics)
- `npm test` (1,453 passed, 1 skipped)
- `npm run release:preflight:toolchain`
- parsed `.github/workflows/ci.yml` with the repository `js-yaml` dependency
- `git diff --check origin/main...HEAD`

`actionlint` was not installed locally; GitHub Actions will perform authoritative workflow validation on this PR.

## Risks
- main-push runs are deliberately no longer cancelled, so rapid merges can consume more runner capacity in exchange for complete SHA-level validation and audit history.
- strict protection can require contributors to update a green PR whenever `main` advances.

Fixes #89