### PR TITLE
Add typed i18n foundation with Simplified Chinese

### DIFF
--- a/electron/main/settings-schedules.ts
+++ b/electron/main/settings-schedules.ts
@@ -19,6 +19,10 @@ export class SettingsService {
         if (value !== 'system' && value !== 'light' && value !== 'dark') throw new TypeError('Invalid theme')
         return value
       },
+      locale: (value) => {
+        if (value !== 'system' && value !== 'en' && value !== 'zh-CN') throw new TypeError('Invalid locale')
+        return value
+      },
       interfaceFontScale: (value) => {
         if (!INTERFACE_FONT_SCALES.includes(value as AppSettings['interfaceFontScale'])) throw new TypeError('Invalid interface font scale')
         return value as AppSettings['interfaceFontScale']

--- a/electron/main/store.ts
+++ b/electron/main/store.ts
@@ -101,6 +101,7 @@ export function defaultSettings(): AppSettings {
     : (process.env.SHELL?.startsWith('/') ? process.env.SHELL : '/bin/zsh')
   return {
     theme: 'system',
+    locale: 'system',
     interfaceFontScale: 110,
     sidebarOpen: true,
     inspectorOpen: true,
@@ -215,6 +216,7 @@ function parseSettings(value: unknown, legacyState = false): AppSettings {
     : legacyState ? 'prime' : defaults.activeHarness
   return {
     theme: value.theme === 'light' || value.theme === 'dark' || value.theme === 'system' ? value.theme : defaults.theme,
+    locale: value.locale === 'en' || value.locale === 'zh-CN' || value.locale === 'system' ? value.locale : defaults.locale,
     interfaceFontScale: INTERFACE_FONT_SCALES.includes(value.interfaceFontScale as AppSettings['interfaceFontScale'])
       ? value.interfaceFontScale as AppSettings['interfaceFontScale']
       : defaults.interfaceFontScale,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { createAppKeydownHandler } from '@/lib/app-shortcuts'
 import { detectRendererPlatform } from '@/lib/platform-shortcuts'
 import { activityNotificationSignature, readClearedActivity, readClearedAttention, sessionCompanionNotificationSignature } from '@/app/session-attention'
 import { errorMessage } from '@/lib/errors'
+import { I18nProvider } from '@/lib/i18n'
 import { openExternalUrl, revealPath } from '@/lib/desktop-actions'
 import { createSingleFlightAdmission, findProjectForSession, gitStatusForWorkspace, shouldRefreshGitOnSessionTransition, workspaceCwd } from '@/lib/workspace'
 import { waitForVoiceSession } from '@/lib/voice'
@@ -502,7 +503,7 @@ export default function App() {
         setBrowserGeneration((value) => value + 1)
       }} onOpenDocs={() => openExternal(HARNESS_PROVIDER_DOCS[activeHarness])} /> : null
 
-  return <div className="app-shell" aria-busy={!initialized} data-platform={platform} data-ready={initialized ? 'true' : 'false'}>
+  return <I18nProvider preference={settingsState.settings.locale}><div className="app-shell" aria-busy={!initialized} data-platform={platform} data-ready={initialized ? 'true' : 'false'}>
     {sidebarVisible && initialized ? <Sidebar projects={projects} sessions={sessions} clearedAttention={clearedAttention} activeProjectId={activeProject?.id} activeSessionId={workspace.activeSessionId} activeView={view} activeHarness={activeHarness} harnesses={meta?.harnesses ?? null} updateState={appUpdates.state} onUpdateAction={appUpdates.act} onSelectHarness={selectHarness} {...sidebarActions} overlay={layout.compactLayout} platform={platform} /> : null}
     {sidebarVisible && initialized ? <button type="button" className="panel-scrim panel-scrim--sidebar" aria-label="Close sidebar" onClick={toggleSidebar} /> : null}
     <div className="workbench" inert={layout.compactLayout && sidebarVisible ? true : undefined}>
@@ -540,5 +541,5 @@ export default function App() {
     ) : null}
     {toast ? <div className="toast" role="status">{toast}<button type="button" aria-label="Dismiss" onClick={() => setToast(null)}>×</button></div> : null}
     {bridge ? <AgentBrowserLayer tabs={agentBrowser.tabs} visibleTabId={agentTabVisible ? activeAgentTabId : null} rect={agentTabVisible ? agentSlotRect : null} pointerEvent={agentBrowser.pointerEvent} onAttach={agentBrowser.attach} /> : null}
-  </div>
+  </div></I18nProvider>
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -26,6 +26,7 @@ import { memo, useEffect, useMemo, useState, type CSSProperties, type ReactEleme
 import type { AppMeta, AppUpdateState, HarnessId, ProjectRecord, SessionRecord, WorkspaceView } from '@/types/api'
 import { formatRelative } from '@/lib/data'
 import { HARNESS_PRODUCT_NAMES, HARNESS_SELECTOR_ORDER, HARNESS_SHORT_NAMES } from '@/lib/harness'
+import { useI18n } from '@/lib/i18n'
 import { shortcutLabel } from '@/lib/platform-shortcuts'
 import { sessionAttentionSignature } from '@/app/session-attention'
 import { IconButton, Modal, OmpMark, PiMark, PrimeMark, useFocusTrap } from './ui'
@@ -177,6 +178,7 @@ async function copySessionUuid(id: string): Promise<void> {
 }
 
 function SidebarView({ projects, sessions, activeProjectId, activeSessionId, activeView, activeHarness = 'omp', harnesses, clearedAttention = {}, updateState = { phase: 'unsupported' }, onUpdateAction, onSelectHarness, onSelectProject, onSelectSession, onNavigate, onNewSession, onAddProject, onRemoveProject, onClose, onOpenPalette, onRenameSession, onArchiveSession, overlay = false, platform = 'darwin' }: SidebarProps) {
+  const { t } = useI18n()
   const [query, setQuery] = useState('')
   const [harnessMenuOpen, setHarnessMenuOpen] = useState(false)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
@@ -290,10 +292,10 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
             {query ? <button type="button" title="Clear search" aria-label="Clear search" onClick={() => setQuery('')}>×</button> : null}
           </div>
         ) : null}
-        <button type="button" title="Projects" className={activeView === 'projects' ? 'is-active' : ''} onClick={() => onNavigate('projects')}><Folder size={15} /><span>Projects</span></button>
-        <button type="button" title="Activity" className={activeView === 'activity' ? 'is-active' : ''} onClick={() => onNavigate('activity')}><Bell size={15} /><span>Activity</span>{unreadCount ? <span className="nav-count">{unreadCount}</span> : null}</button>
-        <button type="button" title="Scheduled" className={activeView === 'scheduled' ? 'is-active' : ''} onClick={() => onNavigate('scheduled')}><CalendarClock size={15} /><span>Scheduled</span></button>
-        <button type="button" title="Capabilities" className={activeView === 'plugins' ? 'is-active' : ''} onClick={() => onNavigate('plugins')}><PackageOpen size={15} /><span>Capabilities</span></button>
+        <button type="button" title={t('nav.projects')} className={activeView === 'projects' ? 'is-active' : ''} onClick={() => onNavigate('projects')}><Folder size={15} /><span>{t('nav.projects')}</span></button>
+        <button type="button" title={t('nav.activity')} className={activeView === 'activity' ? 'is-active' : ''} onClick={() => onNavigate('activity')}><Bell size={15} /><span>{t('nav.activity')}</span>{unreadCount ? <span className="nav-count">{unreadCount}</span> : null}</button>
+        <button type="button" title={t('nav.scheduled')} className={activeView === 'scheduled' ? 'is-active' : ''} onClick={() => onNavigate('scheduled')}><CalendarClock size={15} /><span>{t('nav.scheduled')}</span></button>
+        <button type="button" title={t('nav.capabilities')} className={activeView === 'plugins' ? 'is-active' : ''} onClick={() => onNavigate('plugins')}><PackageOpen size={15} /><span>{t('nav.capabilities')}</span></button>
       </nav>
 
       <div className="sidebar__scroll scroll-area">
@@ -370,7 +372,7 @@ function SidebarView({ projects, sessions, activeProjectId, activeSessionId, act
             </button>
           </>
         ) : null}
-        <button type="button" title="Settings" className={activeView === 'settings' ? 'is-active' : ''} onClick={() => onNavigate('settings')}><Settings size={15} /><span>Settings</span><kbd>{settingsShortcut}</kbd></button>
+        <button type="button" title={t('nav.settings')} className={activeView === 'settings' ? 'is-active' : ''} onClick={() => onNavigate('settings')}><Settings size={15} /><span>{t('nav.settings')}</span><kbd>{settingsShortcut}</kbd></button>
       </div>
       {renameTarget ? <Modal title="Rename session" onClose={() => setRenameTarget(null)} footer={<><button type="button" className="button" onClick={() => setRenameTarget(null)}>Cancel</button><button type="button" className="button button--primary" disabled={!renameValue.trim()} onClick={() => { const target = renameTarget; const title = renameValue.trim(); setRenameTarget(null); void onRenameSession(target, title) }}>Rename</button></>}><label className="field"><span>Session name</span><input autoFocus value={renameValue} maxLength={200} onChange={(event) => setRenameValue(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter' && renameValue.trim()) { event.preventDefault(); const target = renameTarget; const title = renameValue.trim(); setRenameTarget(null); void onRenameSession(target, title) } }}/></label></Modal> : null}
       {removeTarget ? <Modal title="Remove project" onClose={() => setRemoveTarget(null)} footer={<><button type="button" className="button" onClick={() => setRemoveTarget(null)}>Cancel</button><button type="button" className="button button--danger" onClick={() => { const target = removeTarget; setRemoveTarget(null); onRemoveProject(target) }}>Remove</button></>}><p>Remove “{removeTarget.name}” from {HARNESS_PRODUCT_NAMES[activeHarness]}? The folder and saved sessions will not be deleted.</p></Modal> : null}

--- a/src/components/TitleToolbar.tsx
+++ b/src/components/TitleToolbar.tsx
@@ -6,12 +6,13 @@ import {
   Terminal,
 } from 'lucide-react'
 import type { ApplicationMenuName, ProjectRecord, WorkspaceView } from '@/types/api'
+import { useI18n, type MessageKey } from '@/lib/i18n'
 import { shortcutLabel } from '@/lib/platform-shortcuts'
 import { BrowserGlobe, IconButton } from './ui'
 import type { MouseEvent } from 'react'
 
-const viewTitles: Record<Exclude<WorkspaceView, 'session'>, string> = {
-  projects: 'Projects', activity: 'Activity', scheduled: 'Scheduled', plugins: 'Capabilities', settings: 'Settings',
+const viewTitles: Record<Exclude<WorkspaceView, 'session'>, MessageKey> = {
+  projects: 'nav.projects', activity: 'nav.activity', scheduled: 'nav.scheduled', plugins: 'nav.capabilities', settings: 'nav.settings',
 }
 
 const windowsMenus: ReadonlyArray<{ name: ApplicationMenuName; label: string }> = [
@@ -45,6 +46,7 @@ interface TitleToolbarProps {
 }
 
 export function TitleToolbar({ project, view, productName = 'Prime Work', sidebarOpen, inspectorOpen, terminalOpen, voiceOpen = false, onToggleSidebar, onToggleInspector, onToggleTerminal, onOpenBrowser, onToggleVoice, platform = 'darwin' }: TitleToolbarProps) {
+  const { t } = useI18n()
   const sidebarShortcut = shortcutLabel(platform, ['Primary', 'B'])
   const terminalShortcut = shortcutLabel(platform, ['Primary', 'J'])
   const browserShortcut = shortcutLabel(platform, ['Primary', 'Shift', 'B'])
@@ -58,7 +60,7 @@ export function TitleToolbar({ project, view, productName = 'Prime Work', sideba
         {!sidebarOpen ? <IconButton label={`Show sidebar (${sidebarShortcut})`} onClick={onToggleSidebar}><PanelLeft size={16} /></IconButton> : null}
       </div>
       <div className="title-toolbar__identity">
-        <strong>{project?.name ?? (view === 'session' ? productName : viewTitles[view])}</strong>
+        <strong>{project?.name ?? (view === 'session' ? productName : t(viewTitles[view]))}</strong>
         {project?.gitBranch && view === 'session' ? <span className="branch-pill"><GitBranch size={12} />{project.gitBranch}</span> : null}
       </div>
       <div className="title-toolbar__actions no-drag">

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -10,6 +10,7 @@ import type {
 
 export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'system',
+  locale: 'system',
   interfaceFontScale: 110,
   activeHarness: 'omp',
   ompApprovalMode: 'inherit',

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,0 +1,136 @@
+import { createContext, useContext, useEffect, useMemo, type ReactNode } from 'react'
+import type { LocalePreference } from '@/types/api'
+
+type Message = string | { one: string; other: string }
+type MessageValues = Record<string, string | number>
+
+const englishCatalog = {
+  'common.reload': 'Reload GooeyPi',
+  'nav.projects': 'Projects',
+  'nav.activity': 'Activity',
+  'nav.scheduled': 'Scheduled',
+  'nav.capabilities': 'Capabilities',
+  'nav.settings': 'Settings',
+  'settings.sections': 'Settings sections',
+  'settings.general': 'General',
+  'settings.appearance': 'Appearance',
+  'settings.harness': 'Harness',
+  'settings.providers': 'Providers',
+  'settings.voice': 'Voice',
+  'settings.pets': 'Pets',
+  'settings.browser': 'Browser',
+  'settings.terminal': 'Terminal',
+  'settings.privacy': 'Privacy',
+  'settings.about': 'About',
+  'appearance.title': 'Appearance',
+  'appearance.description': 'Keep the workspace comfortable in any environment.',
+  'appearance.theme.title': 'Theme',
+  'appearance.theme.system': 'System',
+  'appearance.theme.light': 'Light',
+  'appearance.theme.dark': 'Dark',
+  'appearance.language.title': 'Language',
+  'appearance.language.label': 'Interface language',
+  'appearance.language.description': 'Choose the language used in GooeyPi.',
+  'appearance.language.system': 'System default',
+  'appearance.language.english': 'English',
+  'appearance.language.chinese': 'Simplified Chinese',
+  'appearance.language.available': { one: '{count} language available', other: '{count} languages available' },
+  'appearance.text.title': 'Text size',
+  'appearance.text.label': 'Interface text',
+  'appearance.text.description': 'Increase readability while keeping the workspace proportions intact.',
+  'appearance.text.aria': 'Interface text size',
+  'appearance.text.smaller': 'Smaller',
+  'appearance.text.default': 'Default',
+  'appearance.text.larger': 'Larger',
+  'appearance.motion.title': 'Motion',
+  'appearance.motion.reduce': 'Reduce interface motion',
+  'appearance.motion.description': 'Minimize panel transitions and animated status indicators.',
+} as const satisfies Record<string, Message>
+
+export type MessageKey = keyof typeof englishCatalog
+export type ResolvedLocale = 'en' | 'zh-CN'
+
+const simplifiedChineseCatalog: Partial<Record<MessageKey, Message>> = {
+  'nav.projects': '项目',
+  'nav.activity': '动态',
+  'nav.scheduled': '定时任务',
+  'nav.capabilities': '功能',
+  'nav.settings': '设置',
+  'settings.sections': '设置分类',
+  'settings.general': '常规',
+  'settings.appearance': '外观',
+  'settings.harness': '运行环境',
+  'settings.providers': '服务商',
+  'settings.voice': '语音',
+  'settings.pets': '宠物',
+  'settings.browser': '浏览器',
+  'settings.terminal': '终端',
+  'settings.privacy': '隐私',
+  'settings.about': '关于',
+  'appearance.title': '外观',
+  'appearance.description': '在任何环境中都能舒适地使用工作区。',
+  'appearance.theme.title': '主题',
+  'appearance.theme.system': '跟随系统',
+  'appearance.theme.light': '浅色',
+  'appearance.theme.dark': '深色',
+  'appearance.language.title': '语言',
+  'appearance.language.label': '界面语言',
+  'appearance.language.description': '选择 GooeyPi 界面所使用的语言。',
+  'appearance.language.system': '跟随系统',
+  'appearance.language.english': '英语',
+  'appearance.language.chinese': '简体中文',
+  'appearance.language.available': { one: '支持 {count} 种语言', other: '支持 {count} 种语言' },
+  'appearance.text.title': '文本大小',
+  'appearance.text.label': '界面文本',
+  'appearance.text.description': '提高可读性，同时保持工作区比例不变。',
+  'appearance.text.aria': '界面文本大小',
+  'appearance.text.smaller': '较小',
+  'appearance.text.default': '默认',
+  'appearance.text.larger': '较大',
+  'appearance.motion.title': '动效',
+  'appearance.motion.reduce': '减少界面动效',
+  'appearance.motion.description': '尽量减少面板过渡和动态状态指示。',
+}
+
+function browserLanguages(): readonly string[] {
+  if (typeof navigator === 'undefined') return []
+  return navigator.languages.length ? navigator.languages : [navigator.language]
+}
+
+export function resolveLocale(preference: LocalePreference, languages: readonly string[] = browserLanguages()): ResolvedLocale {
+  if (preference !== 'system') return preference
+  for (const language of languages) {
+    const normalized = language.toLowerCase()
+    if (normalized === 'zh' || normalized === 'zh-cn' || normalized === 'zh-sg' || normalized === 'zh-hans' || normalized.startsWith('zh-hans-')) return 'zh-CN'
+  }
+  return 'en'
+}
+
+export function translate(locale: ResolvedLocale, key: MessageKey, values: MessageValues = {}): string {
+  const translated = locale === 'zh-CN' ? simplifiedChineseCatalog[key] : undefined
+  const message = translated ?? englishCatalog[key]
+  const template = typeof message === 'string'
+    ? message
+    : message[new Intl.PluralRules(locale).select(Number(values.count)) === 'one' ? 'one' : 'other']
+  return Object.entries(values).reduce((result, [name, value]) => result.split(`{${name}}`).join(String(value)), template)
+}
+
+interface I18nContextValue {
+  locale: ResolvedLocale
+  t(key: MessageKey, values?: MessageValues): string
+}
+
+const I18nContext = createContext<I18nContextValue>({ locale: 'en', t: (key, values) => translate('en', key, values) })
+
+export function I18nProvider({ preference, children }: { preference: LocalePreference; children: ReactNode }) {
+  const locale = resolveLocale(preference)
+  const value = useMemo<I18nContextValue>(() => ({ locale, t: (key, values) => translate(locale, key, values) }), [locale])
+  useEffect(() => {
+    document.documentElement.lang = locale
+  }, [locale])
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
+}
+
+export function useI18n(): I18nContextValue {
+  return useContext(I18nContext)
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { AudioLines, Bot, Boxes, ChevronRight, Info, LockKeyhole, PawPrint, Settings2, Sun, Terminal } from 'lucide-react'
 import { useEffect, useState, type ComponentType } from 'react'
 import { errorMessage } from '@/lib/errors'
+import { useI18n, type MessageKey } from '@/lib/i18n'
 import { detectRendererPlatform } from '@/lib/platform-shortcuts'
 import { BrowserGlobe, Modal } from '@/components/ui'
 import type { AppMeta, AppSettings, PrimeModelCatalog, PrimeWorkApi } from '@/types/api'
@@ -16,17 +17,17 @@ import { ProvidersSettings } from './settings/ProviderSettings'
 import { TerminalSettings } from './settings/TerminalSettings'
 import { VoiceSettings } from './settings/VoiceSettings'
 
-const sections: Array<{ id: SettingsSection; label: string; icon: ComponentType<{ size?: number }> }> = [
-  { id: 'general', label: 'General', icon: Settings2 },
-  { id: 'appearance', label: 'Appearance', icon: Sun },
-  { id: 'agent', label: 'Agent', icon: Bot },
-  { id: 'providers', label: 'Providers', icon: Boxes },
-  { id: 'voice', label: 'Voice', icon: AudioLines },
-  { id: 'pets', label: 'Pets', icon: PawPrint },
-  { id: 'browser', label: 'Browser', icon: BrowserGlobe },
-  { id: 'terminal', label: 'Terminal', icon: Terminal },
-  { id: 'privacy', label: 'Privacy', icon: LockKeyhole },
-  { id: 'about', label: 'About', icon: Info },
+const sections: Array<{ id: SettingsSection; label: MessageKey; icon: ComponentType<{ size?: number }> }> = [
+  { id: 'general', label: 'settings.general', icon: Settings2 },
+  { id: 'appearance', label: 'settings.appearance', icon: Sun },
+  { id: 'agent', label: 'settings.harness', icon: Bot },
+  { id: 'providers', label: 'settings.providers', icon: Boxes },
+  { id: 'voice', label: 'settings.voice', icon: AudioLines },
+  { id: 'pets', label: 'settings.pets', icon: PawPrint },
+  { id: 'browser', label: 'settings.browser', icon: BrowserGlobe },
+  { id: 'terminal', label: 'settings.terminal', icon: Terminal },
+  { id: 'privacy', label: 'settings.privacy', icon: LockKeyhole },
+  { id: 'about', label: 'settings.about', icon: Info },
 ]
 
 interface SettingsPageProps {
@@ -57,6 +58,7 @@ export function SettingsPage({ settings, meta, providerCatalog, voice, pets, onU
   const [confirmReset, setConfirmReset] = useState(false)
   const [resetting, setResetting] = useState(false)
   const [resetError, setResetError] = useState('')
+  const { t } = useI18n()
   const platform = meta?.platform ?? detectRendererPlatform()
 
   useEffect(() => { setSection(initialSection) }, [initialSection, initialSectionRequestId])
@@ -91,13 +93,12 @@ export function SettingsPage({ settings, meta, providerCatalog, voice, pets, onU
 
   return (
     <div className="settings-page">
-      <nav className="settings-nav" aria-label="Settings sections">
+      <nav className="settings-nav" aria-label={t('settings.sections')}>
         {sections.map((item) => {
           const Icon = item.icon
-          const label = item.id === 'agent' ? 'Harness' : item.label
           return (
             <button type="button" key={item.id} className={section === item.id ? 'is-active' : ''} onClick={() => setSection(item.id)}>
-              <Icon size={14} /><span>{label}</span><ChevronRight size={12} />
+              <Icon size={14} /><span>{t(item.label)}</span><ChevronRight size={12} />
             </button>
           )
         })}

--- a/src/pages/settings/AppearanceSettings.tsx
+++ b/src/pages/settings/AppearanceSettings.tsx
@@ -1,19 +1,26 @@
 import { Check, Laptop, Moon, Sun } from 'lucide-react'
 import type { KeyboardEvent } from 'react'
-import type { InterfaceFontScale, ThemeMode } from '@/types/api'
+import { useI18n, type MessageKey } from '@/lib/i18n'
+import type { InterfaceFontScale, LocalePreference, ThemeMode } from '@/types/api'
 import type { SettingsSectionProps } from './contracts'
 import { SettingsToggle } from './SettingsToggle'
 
-const themes: Array<{ id: ThemeMode; label: string; icon: typeof Sun }> = [
-  { id: 'system', label: 'System', icon: Laptop },
-  { id: 'light', label: 'Light', icon: Sun },
-  { id: 'dark', label: 'Dark', icon: Moon },
+const themes: Array<{ id: ThemeMode; label: MessageKey; icon: typeof Sun }> = [
+  { id: 'system', label: 'appearance.theme.system', icon: Laptop },
+  { id: 'light', label: 'appearance.theme.light', icon: Sun },
+  { id: 'dark', label: 'appearance.theme.dark', icon: Moon },
 ]
 
-const fontScales: Array<{ value: InterfaceFontScale; label: string }> = [
-  { value: 105, label: 'Smaller' },
-  { value: 110, label: 'Default' },
-  { value: 115, label: 'Larger' },
+const fontScales: Array<{ value: InterfaceFontScale; label: MessageKey }> = [
+  { value: 105, label: 'appearance.text.smaller' },
+  { value: 110, label: 'appearance.text.default' },
+  { value: 115, label: 'appearance.text.larger' },
+]
+
+const locales: Array<{ value: LocalePreference; label: MessageKey }> = [
+  { value: 'system', label: 'appearance.language.system' },
+  { value: 'en', label: 'appearance.language.english' },
+  { value: 'zh-CN', label: 'appearance.language.chinese' },
 ]
 
 /** Arrow/Home/End movement inside a radio group selects as it moves. */
@@ -26,6 +33,7 @@ function nextScaleIndex(key: string, current: number, count: number): number | n
 }
 
 export function AppearanceSettings({ settings, onUpdate }: SettingsSectionProps) {
+  const { t } = useI18n()
   const selectedScale = Math.max(0, fontScales.findIndex((option) => option.value === settings.interfaceFontScale))
   const onScaleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const next = nextScaleIndex(event.key, selectedScale, fontScales.length)
@@ -37,25 +45,34 @@ export function AppearanceSettings({ settings, onUpdate }: SettingsSectionProps)
   }
   return (
     <>
-      <header><h1>Appearance</h1><p>Keep the workspace comfortable in any environment.</p></header>
+      <header><h1>{t('appearance.title')}</h1><p>{t('appearance.description')}</p></header>
       <section className="settings-group">
-        <h2>Theme</h2>
+        <h2>{t('appearance.theme.title')}</h2>
         <div className="theme-options">
           {themes.map((item) => {
             const Icon = item.icon
             return (
               <button type="button" key={item.id} className={settings.theme === item.id ? 'is-active' : ''} onClick={() => { void onUpdate({ theme: item.id }) }}>
-                <span><Icon size={17} /></span><strong>{item.label}</strong>{settings.theme === item.id ? <Check size={13} /> : null}
+                <span><Icon size={17} /></span><strong>{t(item.label)}</strong>{settings.theme === item.id ? <Check size={13} /> : null}
               </button>
             )
           })}
         </div>
       </section>
       <section className="settings-group">
-        <h2>Text size</h2>
+        <h2>{t('appearance.language.title')}</h2>
+        <label className="settings-row">
+          <span><strong>{t('appearance.language.label')}</strong><small>{t('appearance.language.description')} {t('appearance.language.available', { count: locales.length - 1 })}</small></span>
+          <select value={settings.locale} onChange={(event) => { void onUpdate({ locale: event.target.value as LocalePreference }) }}>
+            {locales.map((locale) => <option key={locale.value} value={locale.value}>{t(locale.label)}</option>)}
+          </select>
+        </label>
+      </section>
+      <section className="settings-group">
+        <h2>{t('appearance.text.title')}</h2>
         <div className="settings-row settings-row--text-size">
-          <span><strong>Interface text</strong><small>Increase readability while keeping the workspace proportions intact.</small></span>
-          <div className="text-size-options" role="radiogroup" aria-label="Interface text size" onKeyDown={onScaleKeyDown}>
+          <span><strong>{t('appearance.text.label')}</strong><small>{t('appearance.text.description')}</small></span>
+          <div className="text-size-options" role="radiogroup" aria-label={t('appearance.text.aria')} onKeyDown={onScaleKeyDown}>
             {fontScales.map((option, index) => (
               <button
                 type="button"
@@ -66,15 +83,15 @@ export function AppearanceSettings({ settings, onUpdate }: SettingsSectionProps)
                 className={settings.interfaceFontScale === option.value ? 'is-active' : ''}
                 onClick={() => { void onUpdate({ interfaceFontScale: option.value }) }}
               >
-                {option.label}
+                {t(option.label)}
               </button>
             ))}
           </div>
         </div>
       </section>
       <section className="settings-group">
-        <h2>Motion</h2>
-        <SettingsToggle checked={settings.reduceMotion} onChange={(reduceMotion) => { void onUpdate({ reduceMotion }) }} label="Reduce interface motion" description="Minimize panel transitions and animated status indicators." />
+        <h2>{t('appearance.motion.title')}</h2>
+        <SettingsToggle checked={settings.reduceMotion} onChange={(reduceMotion) => { void onUpdate({ reduceMotion }) }} label={t('appearance.motion.reduce')} description={t('appearance.motion.description')} />
       </section>
     </>
   )

--- a/src/pages/settings/contracts.ts
+++ b/src/pages/settings/contracts.ts
@@ -16,6 +16,7 @@ export interface SettingsMetaSectionProps extends SettingsSectionProps {
 
 export const SETTINGS_FIELD_SECTIONS = {
   theme: 'appearance',
+  locale: 'appearance',
   interfaceFontScale: 'appearance',
   sidebarOpen: 'general',
   inspectorOpen: 'general',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -399,9 +399,12 @@ export interface SessionActionSnapshot {
 
 export const INTERFACE_FONT_SCALES = [105, 110, 115] as const
 export type InterfaceFontScale = typeof INTERFACE_FONT_SCALES[number]
+export const LOCALE_PREFERENCES = ['system', 'en', 'zh-CN'] as const
+export type LocalePreference = typeof LOCALE_PREFERENCES[number]
 
 export interface AppSettings {
   theme: ThemeMode
+  locale: LocalePreference
   /** Bounded interface text scale; 110 is the designed default. */
   interfaceFontScale: InterfaceFontScale
   sidebarOpen: boolean

--- a/tests/backend/settings-service.test.ts
+++ b/tests/backend/settings-service.test.ts
@@ -21,6 +21,7 @@ describe('SettingsService.update', () => {
     const service = makeService()
     const next = await service.update({
       theme: 'dark',
+      locale: 'zh-CN',
       interfaceFontScale: 105,
       sidebarOpen: false,
       inspectorOpen: true,
@@ -62,7 +63,7 @@ describe('SettingsService.update', () => {
       voiceRealtimeVoice: 'cedar',
     })
     expect(next).toMatchObject({
-      theme: 'dark', interfaceFontScale: 105, sidebarOpen: false, inspectorOpen: true, showFileChangesPopup: false, terminalOpen: true,
+      theme: 'dark', locale: 'zh-CN', interfaceFontScale: 105, sidebarOpen: false, inspectorOpen: true, showFileChangesPopup: false, terminalOpen: true,
       defaultInspectorTab: 'changes', browserHome: 'https://example.test/',
       browserAskForDownloads: false, terminalShell: '/bin/zsh', reduceMotion: true,
       showReasoningSummaries: false, showToolCalls: false, messageEnterAction: 'steer',
@@ -90,6 +91,7 @@ describe('SettingsService.update', () => {
     await expect(service.update({ nope: true })).rejects.toThrow(/not supported/)
     await expect(service.update('dark')).rejects.toThrow(/must be an object/)
     await expect(service.update({ theme: 'solarized' })).rejects.toThrow(/Invalid theme/)
+    await expect(service.update({ locale: 'fr' })).rejects.toThrow(/Invalid locale/)
     await expect(service.update({ interfaceFontScale: 111 })).rejects.toThrow(/Invalid interface font scale/)
     await expect(service.update({ defaultInspectorTab: 'tools' })).rejects.toThrow(/Invalid inspector tab/)
     await expect(service.update({ messageEnterAction: 'send' })).rejects.toThrow(/Invalid message Enter action/)

--- a/tests/backend/store.test.ts
+++ b/tests/backend/store.test.ts
@@ -54,6 +54,17 @@ describe('JsonStateStore', () => {
     expect(new JsonStateStore(path).getSettings().askUserEnabled).toBe(true)
   })
 
+  it('defaults, persists, and validates the locale preference', async () => {
+    const dir = makeDirectory()
+    const path = join(dir, 'state.json')
+    const settings = { ...defaultSettings(), locale: 'zh-CN' as const }
+    writeFileSync(path, JSON.stringify({ version: 4, projects: [], settings, archivedSessions: [], dismissedProjectPaths: [], schedules: [] }))
+    expect(new JsonStateStore(path).getSettings().locale).toBe('zh-CN')
+
+    writeFileSync(path, JSON.stringify({ version: 4, projects: [], settings: { ...settings, locale: 'fr' }, archivedSessions: [], dismissedProjectPaths: [], schedules: [] }))
+    expect(new JsonStateStore(path).getSettings().locale).toBe('system')
+  })
+
   it('serializes concurrent updates without losing data', async () => {
     const dir = makeDirectory()
     const path = join(dir, 'state.json')

--- a/tests/frontend/appearance-settings.test.tsx
+++ b/tests/frontend/appearance-settings.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_SETTINGS } from '../../src/lib/data'
+import { I18nProvider } from '../../src/lib/i18n'
 import { AppearanceSettings } from '../../src/pages/settings/AppearanceSettings'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -32,6 +33,26 @@ describe('AppearanceSettings', () => {
 
     act(() => options[2].click())
     expect(update).toHaveBeenCalledWith({ interfaceFontScale: 115 })
+  })
+
+  it('renders Simplified Chinese, translates accessibility text, and persists a locale override', () => {
+    const update = vi.fn()
+    act(() => root.render(
+      <I18nProvider preference="zh-CN">
+        <AppearanceSettings settings={{ ...DEFAULT_SETTINGS, locale: 'zh-CN' }} onUpdate={update} />
+      </I18nProvider>,
+    ))
+
+    expect(container.querySelector('h1')?.textContent).toBe('外观')
+    expect(container.querySelector('[role="radiogroup"]')?.getAttribute('aria-label')).toBe('界面文本大小')
+    expect(container.textContent).toContain('支持 2 种语言')
+    const locale = container.querySelector<HTMLSelectElement>('select')!
+    expect([...locale.options].map((option) => option.textContent)).toEqual(['跟随系统', '英语', '简体中文'])
+    act(() => {
+      locale.value = 'en'
+      locale.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(update).toHaveBeenCalledWith({ locale: 'en' })
   })
 
   it('exposes one tab stop and selects the interface size with arrow, Home, and End keys', () => {

--- a/tests/frontend/i18n.test.ts
+++ b/tests/frontend/i18n.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLocale, translate } from '../../src/lib/i18n'
+
+describe('i18n', () => {
+  it('detects Simplified Chinese system locales without treating Traditional Chinese as Simplified', () => {
+    expect(resolveLocale('system', ['zh-CN'])).toBe('zh-CN')
+    expect(resolveLocale('system', ['zh-Hans-US'])).toBe('zh-CN')
+    expect(resolveLocale('system', ['zh-TW', 'en-US'])).toBe('en')
+    expect(resolveLocale('system', ['fr-FR', 'zh-SG'])).toBe('zh-CN')
+  })
+
+  it('honors an explicit locale preference over the system locale', () => {
+    expect(resolveLocale('en', ['zh-CN'])).toBe('en')
+    expect(resolveLocale('zh-CN', ['en-US'])).toBe('zh-CN')
+  })
+
+  it('interpolates values, selects plural forms, and falls back to English', () => {
+    expect(translate('en', 'appearance.language.available', { count: 1 })).toBe('1 language available')
+    expect(translate('en', 'appearance.language.available', { count: 2 })).toBe('2 languages available')
+    expect(translate('zh-CN', 'appearance.language.available', { count: 2 })).toBe('支持 2 种语言')
+    expect(translate('zh-CN', 'common.reload')).toBe('Reload GooeyPi')
+  })
+})

--- a/tests/frontend/settings-page.test.ts
+++ b/tests/frontend/settings-page.test.ts
@@ -144,6 +144,7 @@ describe('settings field ownership', () => {
   it('assigns every AppSettings field to a focused section', () => {
     expect(SETTINGS_FIELD_SECTIONS).toEqual({
       theme: 'appearance',
+      locale: 'appearance',
       interfaceFontScale: 'appearance',
       sidebarOpen: 'general',
       inspectorOpen: 'general',


### PR DESCRIPTION
## Summary
- add a dependency-free typed renderer localization catalog with complete English fallback behavior
- detect Simplified Chinese system locales and persist an explicit language override in Appearance settings
- translate the Appearance vertical slice, settings navigation, primary navigation, and accessibility labels
- cover locale detection, persistence, validation, interpolation, plurals, and fallback behavior

Closes #93

#### Test plan
- [x] `npm test` (1520 passed, 1 skipped)
- [x] `npm run build`
- [x] `npm run check`
- [x] review by two independent subagents

Generated with [Devin](https://devin.ai)