### PR TITLE
chore(release): bump version to 1.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gooeypi",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gooeypi",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gooeypi",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "description": "A desktop workspace for Pi, OMP, and Prime Agent",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary
Bump GooeyPi from 1.1.10 to 1.1.11.

## Test plan
- [x] Validate release tag script passes
- [x] `npm run release:preflight:toolchain`
- [x] `npm run typecheck`
- [x] `npm run check`

Generated with [Devin](https://devin.ai)