### PR TITLE
feat(transcript): show live elapsed time on the work status line

### DIFF
--- a/src/components/Transcript.tsx
+++ b/src/components/Transcript.tsx
@@ -8,7 +8,7 @@ import { HARNESS_SHORT_NAMES } from '@/lib/harness'
 import { OmpMark, PiMark, PrimeMark } from './ui'
 import { ActivityMessage, AgentMessage, AssistantMessage, GoalMessage, SteerReadMarker, UserMessage } from './transcript/messages'
 import { useTranscriptScroll } from './transcript/scroll'
-import { ThinkingDots, WorkDisclosure } from './transcript/timeline'
+import { LiveElapsed, ThinkingDots, WorkDisclosure } from './transcript/timeline'
 
 export { classifyTool, formatWorkedDuration } from './transcript/timeline'
 export { tokenizeSyntax } from './transcript/syntax'
@@ -71,7 +71,7 @@ function ActiveAssistantMessage({ message, harness, showReasoning, showTools }: 
           ? <WorkDisclosure message={message} parts={message.parts} showReasoning={showReasoning} showTools={showTools} running />
           : <>
             {message.parts.map((part, index) => part.type === 'text' ? <MarkdownText key={index} text={part.text} /> : null)}
-            <div className="streaming-state" aria-live="polite"><ThinkingDots /> {HARNESS_SHORT_NAMES[harness]} is working</div>
+            <div className="streaming-state" aria-live="polite"><ThinkingDots /> {HARNESS_SHORT_NAMES[harness]} is working <LiveElapsed since={message.startedAt ?? message.timestamp} /></div>
           </>}
       </div>
     </article>

--- a/src/components/transcript/timeline.tsx
+++ b/src/components/transcript/timeline.tsx
@@ -86,6 +86,25 @@ export function ThinkingDots({ labelled = false }: { labelled?: boolean }) {
   )
 }
 
+/**
+ * Self-ticking elapsed clock for a live work phase. The timer lives inside
+ * this leaf component so only the small label re-renders every second, not
+ * the whole transcript row. `aria-hidden` keeps the 1-second churn out of
+ * screen-reader announcements; the neighbouring state text already carries
+ * the semantic (thinking/working), the duration is decorative.
+ */
+export function LiveElapsed({ since }: { since?: string | number }) {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), 1_000)
+    return () => clearInterval(id)
+  }, [])
+  const startedAt = timestamp(since)
+  if (startedAt === undefined) return null
+  return <span className="live-elapsed" aria-hidden="true">{formatWorkedDuration(Math.max(0, now - startedAt))}</span>
+}
+
 function ToolPart({ part, next }: { part: Extract<MessagePart, { type: 'toolCall' }>; next?: MessagePart }) {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -246,7 +265,7 @@ export function WorkDisclosure({ message, parts, showReasoning, showTools, runni
     return <section className="work-disclosure is-running" aria-label="Agent work activity">
       <span className="work-disclosure__rail" aria-hidden="true" />
       <div className="work-disclosure__live">
-        <div className="work-disclosure__status" role="status"><span>{status}</span><ThinkingDots /></div>
+        <div className="work-disclosure__status" role="status"><span>{status}</span><LiveElapsed since={message.startedAt ?? message.timestamp} /><ThinkingDots /></div>
         <WorkTimeline parts={parts} showReasoning={showReasoning} showTools={showTools} streaming />
       </div>
     </section>

--- a/src/styles/transcript.css
+++ b/src/styles/transcript.css
@@ -64,6 +64,9 @@
 .work-disclosure__live { min-width: 0; }
 .work-disclosure__status { min-height: 20px; display: flex; align-items: center; gap: 6px; margin-bottom: 4px; color: var(--text-tertiary); font-size: 10.5px; font-weight: 560; }
 .work-disclosure__status .thinking-dots { min-width: 29px; }
+/* Live elapsed clock on running work rows: tabular digits keep the 1-second
+   updates from shifting the adjacent dots around. */
+.live-elapsed { font-variant-numeric: tabular-nums; opacity: 0.78; }
 .work-timeline { display: flex; flex-direction: column; gap: 2px; padding: 3px 0 8px 5px; }
 .work-disclosure.is-running .work-timeline { padding: 0 0 8px; }
 .work-disclosure.is-running .activity-line--reasoning { color: var(--text-tertiary); font-size: 12.5px; line-height: 1.55; }

--- a/tests/frontend/transcript-rendering.test.ts
+++ b/tests/frontend/transcript-rendering.test.ts
@@ -2,6 +2,7 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import { Transcript } from '../../src/components/Transcript'
+import { LiveElapsed } from '../../src/components/transcript/timeline'
 import { replayPrimeEvents } from '../../src/lib/events/reduce'
 import type { TranscriptMessage } from '../../src/types/api'
 
@@ -346,6 +347,34 @@ describe('transcript rendering', () => {
     expect(html).toContain('aria-expanded="false"')
     expect(html).not.toContain('Large diagnostic details.')
     expect(html).not.toContain('message--system')
+  })
+
+  it('shows live elapsed time while work is running and keeps the final duration once finished', () => {
+    const running = render([{
+      id: 'live-active',
+      role: 'assistant',
+      timestamp: Date.now() - 65_000,
+      startedAt: Date.now() - 65_000,
+      streaming: true,
+      parts: [{ type: 'thinking', text: 'Still thinking.' }],
+    }], true)
+    expect(running).toContain('live-elapsed')
+    expect(running).toContain('1m05s')
+
+    const finished = render([{
+      id: 'live-done',
+      role: 'assistant',
+      timestamp: Date.now() - 66_000,
+      startedAt: Date.now() - 66_000,
+      completedAt: Date.now() - 1_000,
+      parts: [{ type: 'thinking', text: 'Done thinking.' }],
+    }], false)
+    expect(finished).toContain('Worked for 1m05s')
+    expect(finished).not.toContain('live-elapsed')
+  })
+
+  it('omits the live elapsed label when no start time is available', () => {
+    expect(renderToStaticMarkup(createElement(LiveElapsed, {}))).toBe('')
   })
 
 })


### PR DESCRIPTION
## Summary

While an agent turn is in flight, the work status line only shows *Thinking/Working* with animated dots. A long silent model phase (no tokens yet) looks identical to a hung tool call — there is no way to tell whether the agent is still alive or stuck.

Render a self-ticking elapsed clock next to the status label, and in the silent pre-token placeholder ('{Harness} is working 4m32s'). The counter reuses the existing `formatWorkedDuration` format, keeping one duration language across live and finished states.

## Changes

- `src/components/transcript/timeline.tsx`: new `LiveElapsed` leaf component (1s tick, `aria-hidden`) + wired into the `WorkDisclosure` status line
- `src/components/Transcript.tsx`: wired into the `streaming-state` placeholder
- `src/styles/transcript.css`: tabular numerals so the counter does not jitter
- `tests/frontend/transcript-rendering.test.ts`: live vs finished rendering coverage

## Design notes

- The timer lives inside the leaf component so only the small label re-renders every second, not the transcript row.
- `aria-hidden` keeps the 1-second churn out of screen-reader announcements; the neighbouring state text already carries the semantic.
- Finished turns are untouched — they keep the existing 'Worked for' duration (from #86).

## Verification

- `npx vitest run tests/frontend/transcript-rendering.test.ts` — 27/27 passed
- `npx tsc --noEmit -p tsconfig.web.json` — clean
- `npx biome lint` on changed files — clean

Motivated by live work being indistinguishable from a hang (e.g. while a long MCP tool call is in flight).