### PR TITLE
fix: ignore stale Prime task verdicts

### DIFF
--- a/electron/main/sessions/metadata.ts
+++ b/electron/main/sessions/metadata.ts
@@ -77,6 +77,8 @@ interface MetadataAccumulator {
   preview: string
   lifecycle?: string
   taskState?: string
+  taskStateBasedOnMessageCount?: number
+  messageCount: number
   lastRole?: string
   stopReason?: string
   records: number
@@ -92,6 +94,7 @@ function createAccumulator(filePath: string, fileStat: Stats): MetadataAccumulat
     depth: 0,
     firstUser: '',
     preview: '',
+    messageCount: 0,
     records: 0,
   }
 }
@@ -142,12 +145,21 @@ function ingestMetadataLine(state: MetadataAccumulator, line: string): void {
   } else if (value.type === 'thinking_level_change' && typeof value.thinkingLevel === 'string') state.thinkingLevel = value.thinkingLevel
   else if (value.type === 'session_info' && typeof value.name === 'string') state.sessionName = value.name
   else if (value.type === 'session_state' && isRecord(value.state) && typeof value.state.status === 'string') state.lifecycle = value.state.status
-  else if (value.type === 'agent_status' && isRecord(value.status) && typeof value.status.taskState === 'string') state.taskState = value.status.taskState
-  else if (value.type === 'message') ingestMessageActivity(state, value)
+  else if (value.type === 'agent_status' && isRecord(value.status)) {
+    state.taskState = typeof value.status.taskState === 'string' ? value.status.taskState : undefined
+    state.taskStateBasedOnMessageCount = typeof value.status.basedOnMessageCount === 'number'
+      ? value.status.basedOnMessageCount
+      : undefined
+  } else if (value.type === 'message') {
+    state.messageCount += 1
+    ingestMessageActivity(state, value)
+  }
 }
 
 function metadataFromAccumulator(state: MetadataAccumulator, filePath: string, fallbackUpdated: string): SessionMetadata {
   const title = compactText(state.sessionName || state.firstUser, 100) || 'Untitled session'
+  // Prime verdicts describe exactly the message count they were generated from.
+  const taskState = state.taskStateBasedOnMessageCount === state.messageCount ? state.taskState : undefined
   return {
     id: state.id,
     filePath,
@@ -156,7 +168,7 @@ function metadataFromAccumulator(state: MetadataAccumulator, filePath: string, f
     createdAt: state.createdAt,
     updatedAt: state.sawRecordTimestamp ? state.updatedAt : fallbackUpdated,
     lastUserMessageAt: state.lastUserMessageAt ?? state.createdAt,
-    status: statusFrom(state.taskState, state.lifecycle, state.lastRole, state.stopReason),
+    status: statusFrom(taskState, state.lifecycle, state.lastRole, state.stopReason),
     model: state.model,
     provider: state.provider,
     thinkingLevel: state.thinkingLevel,

--- a/tests/backend/sessions.test.ts
+++ b/tests/backend/sessions.test.ts
@@ -353,6 +353,30 @@ describe('incremental session metadata reads', () => {
   })
 })
 
+describe('Prime task-state freshness', () => {
+  it('ignores a persisted verdict after later messages and accepts a current verdict', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prime-work-task-state-')); dirs.push(dir)
+    const file = join(dir, 'task-state.jsonl')
+    writeFileSync(file, [
+      JSON.stringify({ type: 'session', id: 'task-state', cwd: '/project', timestamp: '2025-01-01T00:00:00.000Z' }),
+      JSON.stringify({ type: 'message', id: 'user', parentId: null, message: { role: 'user', content: 'question' } }),
+      JSON.stringify({ type: 'agent_status', status: { summary: 'Waiting', taskState: 'needs_input', basedOnMessageCount: 1 } }),
+      '',
+    ].join('\n'))
+    const reader = createSessionMetadataReader()
+
+    expect((await reader(file)).status).toBe('waiting')
+
+    appendFileSync(file, `${JSON.stringify({ type: 'message', id: 'assistant', parentId: 'user', message: { role: 'assistant', content: 'answered' } })}\n`)
+    const staleVerdict = await reader(file)
+    expect(staleVerdict.status).toBe('complete')
+    expect(staleVerdict).toEqual(await readSessionMetadata(file))
+
+    appendFileSync(file, `${JSON.stringify({ type: 'agent_status', status: { summary: 'Waiting again', taskState: 'needs_input', basedOnMessageCount: 2 } })}\n`)
+    expect((await reader(file)).status).toBe('waiting')
+  })
+})
+
 describe('SessionService user-message ordering', () => {
   it('ignores later assistant activity until a new user message is sent', async () => {
     const { root, project, service, store } = setup()


### PR DESCRIPTION
## Summary

- track Prime JSONL message counts alongside persisted `agent_status` records
- apply a persisted `taskState` only when its `basedOnMessageCount` still matches the session
- preserve current `needs_input` behavior while allowing later assistant messages to determine the fallback status
- add incremental and one-shot parser coverage for the stale-verdict sequence

## Root cause

GooeyPi's Prime JSONL fallback retained the latest persisted `taskState` without checking which transcript revision produced it. Prime Agent already treats that verdict as current only when `basedOnMessageCount` equals the session's current message count.

If the live `prime-agent list --all --json` catalog was temporarily unavailable, GooeyPi could therefore classify an inactive session as waiting from a stale `needs_input` verdict. When the live catalog recovered and reported the session idle, the status transition preserved unread state and made previously cleared sessions appear new again.

The Pi and OMP bucketed parsers do not consume Prime `agent_status` records and are unchanged.

## Reproduction

1. Parse a Prime session with one message and a `needs_input` status based on message count 1.
2. Append an assistant message without appending a new `agent_status` record.
3. Refresh through the JSONL fallback.
4. Before this change, the session remains waiting; after this change, the stale verdict is ignored and the assistant message determines the completed status.
5. Append a new `needs_input` verdict based on message count 2 and confirm that the current verdict still reports waiting.

## Validation

- `npm run typecheck`
- `npm run check`
- focused Prime, Pi, OMP, and attention tests: 92 passed
- `npm test`: 1,603 passed, 1 skipped
- `npm run build:bundle`
- `npm run test:e2e:hermetic`: 58 passed
- `git diff --check`

Fixes #108
