### PR TITLE
feat(voice): allow private-network hosts for self-hosted HTTP voice URLs

### DIFF
--- a/electron/main/validation.ts
+++ b/electron/main/validation.ts
@@ -82,11 +82,26 @@ export function isLoopbackHostname(value: string): boolean {
   return host === 'localhost' || host.endsWith('.localhost') || host === '127.0.0.1' || host === '[::1]' || host === '::1'
 }
 
+/** Private-network (RFC1918/ULA) or loopback hosts: the safe scope for plaintext-HTTP voice traffic. */
+export function isPrivateOrLoopbackHostname(value: string): boolean {
+  const host = value.toLowerCase()
+  if (isLoopbackHostname(host)) return true
+  const bare = host.startsWith('[') ? host.slice(1, host.indexOf(']')) : host
+  if (bare === '::1' || bare.startsWith('fe80:') || bare.startsWith('fc') || bare.startsWith('fd')) return true
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4) {
+    const first = Number(ipv4[1])
+    const second = Number(ipv4[2])
+    return first === 10 || (first === 172 && second >= 16 && second <= 31) || (first === 192 && second === 168)
+  }
+  return false
+}
+
 export function requireSelfHostedVoiceUrl(value: unknown): string {
   const normalized = requireWebUrl(value, { max: 2_048 })
   const parsed = new URL(normalized)
   if (parsed.search || parsed.hash) throw new TypeError('Self-hosted voice URL cannot contain a query or fragment')
-  if (parsed.protocol === 'http:' && !isLoopbackHostname(parsed.hostname)) throw new TypeError('Self-hosted voice HTTP is allowed only on this computer; use HTTPS or an SSH tunnel for another host')
+  if (parsed.protocol === 'http:' && !isPrivateOrLoopbackHostname(parsed.hostname)) throw new TypeError('Self-hosted voice HTTP is allowed on this computer or private network addresses (10.x, 172.16-31.x, 192.168.x); use HTTPS for public hosts')
   return parsed.toString()
 }
 

--- a/tests/backend/validation.test.ts
+++ b/tests/backend/validation.test.ts
@@ -7,6 +7,7 @@ import {
   requireExistingPath,
   requireGitPath,
   requireId,
+  requireSelfHostedVoiceUrl,
   requireString,
   requireWebUrl,
 } from '../../electron/main/validation'
@@ -186,5 +187,46 @@ describe('requireId', () => {
     expect(() => requireId('')).toThrow(/too short/)
     expect(() => requireId('x'.repeat(257))).toThrow(/too long/)
     expect(requireId('x'.repeat(256))).toHaveLength(256)
+  })
+})
+
+describe('requireSelfHostedVoiceUrl', () => {
+  it('accepts loopback and private-network HTTP hosts', () => {
+    for (const url of [
+      'http://127.0.0.1:8000/',
+      'http://localhost:8000/',
+      'http://[::1]:8000/',
+      'http://192.168.124.8:8000/',
+      'http://10.0.0.5:9000',
+      'http://172.16.0.1:9000',
+      'http://172.31.255.254:9000',
+      'http://[fd12::1]:8000/',
+      'http://[fc00::5]:8000/',
+      'http://[fe80::1]:8000/',
+    ]) expect(requireSelfHostedVoiceUrl(url), url).toMatch(/^https?:/)
+  })
+
+  it('rejects public HTTP hosts but still allows them over HTTPS', () => {
+    for (const url of [
+      'http://1.2.3.4:8000/',
+      'http://8.8.8.8:8000/',
+      'http://9.255.255.255/',
+      'http://172.15.0.1/',
+      'http://172.32.0.1/',
+      'http://192.169.0.1/',
+      'http://example.com/',
+      'http://[2001:db8::1]:8000/',
+    ]) expect(() => requireSelfHostedVoiceUrl(url), url).toThrow(/private network/)
+    expect(requireSelfHostedVoiceUrl('https://example.com/v1/')).toBe('https://example.com/v1/')
+    expect(requireSelfHostedVoiceUrl('https://1.2.3.4:8000/')).toBe('https://1.2.3.4:8000/')
+  })
+
+  it('rejects query and fragment on self-hosted voice URLs', () => {
+    expect(() => requireSelfHostedVoiceUrl('http://192.168.1.2:8000/?x=1')).toThrow(/query or fragment/)
+    expect(() => requireSelfHostedVoiceUrl('http://192.168.1.2:8000/#frag')).toThrow(/query or fragment/)
+  })
+
+  it('normalizes the accepted URL', () => {
+    expect(requireSelfHostedVoiceUrl('http://192.168.124.8:8000')).toBe('http://192.168.124.8:8000/')
   })
 })


### PR DESCRIPTION
## Summary

The self-hosted voice URL guard (`requireSelfHostedVoiceUrl`) previously rejected **every non-loopback HTTP host** ("use HTTPS or an SSH tunnel for another host"), forcing LAN servers behind an SSH tunnel. That tunnel is a flaky extra hop (observed intermittent `setsockopt TCP_NODELAY: Invalid argument` failures on the forwarded sockets), and LAN self-hosted servers (oMLX, local TTS/ASR stacks) are most naturally reached by their private IP.

This relaxes the guard to **loopback + RFC1918/ULA private ranges** (10/8, 172.16/12, 192.168/16, IPv6 ULA/link-local/loopback).

## Security posture

- Public hosts still require HTTPS — plaintext audio never leaves the user's own network via an unencrypted endpoint (the original anti-SSRF intent is preserved).
- The URL is user-configured desktop-app input; the guard remains a belt-and-braces check at the settings boundary.

## Changes

- `electron/main/validation.ts`: new `isPrivateOrLoopbackHostname()`; `requireSelfHostedVoiceUrl` now accepts private-network HTTP hosts with an updated error message.
- `tests/backend/validation.test.ts`: table-driven coverage — loopback/private IPv4+IPv6 accepted, public HTTP rejected (including 172.15/172.32/192.169 boundary cases), public HTTPS accepted, query/fragment rejection, normalization.

## Verified

- `tsc` clean (node + tests configs)
- `tests/backend/validation.test.ts`: 26/26 passing
- End-to-end against a real LAN server (oMLX at a 192.168.x address): ASR + TTS round-trip verified directly without a tunnel
