### PR TITLE
fix(ci): persist bootstrapped npm CLI path

### DIFF
--- a/scripts/release/bootstrap-npm.mjs
+++ b/scripts/release/bootstrap-npm.mjs
@@ -115,6 +115,14 @@ export function persistNpmShimDirectory(shimDirectory, githubPath = process.env.
   return true
 }
 
+export function persistNpmCliPath(cliPath, githubEnv = process.env.GITHUB_ENV, platform = process.platform) {
+  const validatedCliPath = validateAbsoluteSingleLinePath(cliPath, 'npm CLI path', platform)
+  if (!githubEnv) return false
+  const destination = validateAbsoluteSingleLinePath(githubEnv, 'GITHUB_ENV', platform)
+  appendFileSync(destination, `npm_execpath=${validatedCliPath}\n`, 'utf8')
+  return true
+}
+
 export function bootstrapNpm(options = {}) {
   const env = options.env ?? process.env
   const platform = options.platform ?? process.platform
@@ -149,8 +157,9 @@ export function bootstrapNpm(options = {}) {
   if (installed !== toolchain.npm) throw new Error(`Expected pinned npm ${toolchain.npm} after bootstrap, found ${installed}`)
 
   const githubPathUpdated = persist(layout.shimDirectory, env.GITHUB_PATH, platform)
+  const githubEnvUpdated = persistNpmCliPath(layout.cliPath, env.GITHUB_ENV, platform)
   console.log(`Repository toolchain bootstrap passed: Node ${nodeVersion} and npm ${installed}.`)
-  return { current, installed, artifactPath: artifact.path, artifactIntegrity: artifact.integrity, ...layout, githubPathUpdated }
+  return { current, installed, artifactPath: artifact.path, artifactIntegrity: artifact.integrity, ...layout, githubPathUpdated, githubEnvUpdated }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tests/release-scripts.test.ts
+++ b/tests/release-scripts.test.ts
@@ -6,7 +6,15 @@ import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
-import { bootstrapNpm, parsePinnedNpmArtifact, persistNpmShimDirectory, readPinnedNpmArtifact, resolveNpmGlobalLayout, verifyPinnedNpmArtifact } from '../scripts/release/bootstrap-npm.mjs'
+import {
+  bootstrapNpm,
+  parsePinnedNpmArtifact,
+  persistNpmCliPath,
+  persistNpmShimDirectory,
+  readPinnedNpmArtifact,
+  resolveNpmGlobalLayout,
+  verifyPinnedNpmArtifact,
+} from '../scripts/release/bootstrap-npm.mjs'
 import { installAppDependencies } from '../scripts/release/install-app-deps.mjs'
 import {
   artifactArchitectures,
@@ -510,6 +518,20 @@ else if (JSON.stringify(args) === ${JSON.stringify(JSON.stringify(expectedInstal
       expect(entries.at(-1)).toBe('/opt/repository-npm/bin')
       expect(() => persistNpmShimDirectory('/opt/npm\n/injected', githubPath, 'linux')).toThrow(/absolute single-line path/)
       expect(() => persistNpmShimDirectory('/opt/npm/bin', 'relative/github-path', 'linux')).toThrow(/absolute single-line path/)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('persists the bootstrapped npm CLI for direct Node release entry points', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'gooeypi-github-env-'))
+    const githubEnv = join(directory, 'github-env')
+    writeFileSync(githubEnv, '')
+    try {
+      expect(persistNpmCliPath('/opt/repository-npm/lib/node_modules/npm/bin/npm-cli.js', githubEnv, 'linux')).toBe(true)
+      expect(readFileSync(githubEnv, 'utf8')).toBe('npm_execpath=/opt/repository-npm/lib/node_modules/npm/bin/npm-cli.js\n')
+      expect(() => persistNpmCliPath('/opt/npm\n/injected', githubEnv, 'linux')).toThrow(/absolute single-line path/)
+      expect(() => persistNpmCliPath('/opt/npm/bin/npm-cli.js', 'relative/github-env', 'linux')).toThrow(/absolute single-line path/)
     } finally {
       rmSync(directory, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Why

The Windows release runner bootstraps npm 12.0.2 but direct Node packaging still inherits the stale npm_execpath from npm 11.12.1, so the unsigned Windows release leg fails before packaging.

## What Changed

Persist the verified npm CLI path in GITHUB_ENV alongside the shim directory, and add release-script coverage for the persisted environment contract.

## Verification

- npm run release:verify:package
- 1603 tests passed, 1 skipped
- Bundle-size budgets passed