### PR TITLE
Fix system locale preference ordering

### DIFF
--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -101,6 +101,7 @@ export function resolveLocale(preference: LocalePreference, languages: readonly 
   if (preference !== 'system') return preference
   for (const language of languages) {
     const normalized = language.toLowerCase()
+    if (normalized === 'en' || normalized.startsWith('en-')) return 'en'
     if (normalized === 'zh' || normalized === 'zh-cn' || normalized === 'zh-sg' || normalized === 'zh-hans' || normalized.startsWith('zh-hans-')) return 'zh-CN'
   }
   return 'en'

--- a/tests/frontend/i18n.test.ts
+++ b/tests/frontend/i18n.test.ts
@@ -9,6 +9,11 @@ describe('i18n', () => {
     expect(resolveLocale('system', ['fr-FR', 'zh-SG'])).toBe('zh-CN')
   })
 
+  it('uses the first supported system locale in preference order', () => {
+    expect(resolveLocale('system', ['en-US', 'bg-US', 'zh-Hans-US'])).toBe('en')
+    expect(resolveLocale('system', ['zh-Hans-US', 'en-US'])).toBe('zh-CN')
+  })
+
   it('honors an explicit locale preference over the system locale', () => {
     expect(resolveLocale('en', ['zh-CN'])).toBe('en')
     expect(resolveLocale('zh-CN', ['en-US'])).toBe('zh-CN')


### PR DESCRIPTION
## Summary
- treat English as a supported locale while scanning system preferences
- preserve locale preference order instead of allowing later Simplified Chinese entries to override English
- add regression coverage for the macOS language list reported in #112

Closes #112

#### Test plan
- [x] npm test
- [x] npm run check
- [x] npm run build

Generated with [Devin](https://devin.ai)