### PR TITLE
Document credential-free local macOS builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+See the [source setup](README.md#run-from-source) and
+[validation guide](docs/validation.md) for the supported toolchain and checks.
+
+## Local macOS development without release credentials
+
+You do not need access to the signing and notarization credentials for the
+production `app.gooeypi.desktop` bundle. Use `npm run dev` while developing and
+run the relevant checks from the validation guide before submitting a change.
+
+To exercise the normal local packaging pipeline without release credentials,
+run:
+
+```bash
+npm run package:mac:local-qa
+```
+
+This creates unsigned, unnotarized local-QA artifacts. It does not establish
+that a build is ready for public distribution; `npm run package:mac` is reserved
+for maintainers with the release credentials.
+
+As an optional development convenience, use a separate app identity and
+Electron data directory when keeping a local package alongside GooeyPi:
+
+```bash
+npm run build
+npx electron-builder --mac dir --arm64 --publish never \
+  --config.mac.identity=null \
+  --config.mac.notarize=false \
+  --config.productName="GooeyPi Dev" \
+  --config.appId=app.gooeypi.desktop.localdev \
+  --config.extraMetadata.name=gooeypi-local-dev \
+  --config.directories.output=release/local-dev
+```
+
+Use `--x64` instead of `--arm64` on an Intel Mac. The `extraMetadata.name`
+override isolates Electron state under
+`~/Library/Application Support/gooeypi-local-dev`; changing only the product
+name or bundle ID does not isolate it. These values are local examples and must
+not replace the production package metadata.


### PR DESCRIPTION
## Summary

- add a focused contributor guide for local macOS development without production signing or notarization credentials
- point contributors to the existing unsigned local-QA packaging command
- document an optional isolated `GooeyPi Dev` bundle and Electron data profile for side-by-side testing

## Why

Contributors and automated development agents should be able to build and test GooeyPi without access to the production `app.gooeypi.desktop` release configuration. The optional overrides also prevent a locally packaged app from sharing Electron state with an installed production build.

## Validation

- `npm run package:mac:local-qa -- --dry-run`
- `git diff --check`
