### PR TITLE
fix(chat): wrap long user messages in bubbles

### DIFF
--- a/src/styles/transcript.css
+++ b/src/styles/transcript.css
@@ -23,7 +23,7 @@
 .message--steer-read { display: flex; align-items: center; gap: 10px; margin: -5px 0 21px; color: var(--text-tertiary); font-size: 10.5px; }
 .message--steer-read::before, .message--steer-read::after { height: 1px; flex: 1; background: var(--border); content: ''; }
 .message--steer-read span { flex: 0 0 auto; }
-.user-bubble { max-width: 88%; padding: 9px 13px; border-radius: 15px; border-bottom-right-radius: 5px; background: var(--surface-subtle); color: var(--text); font-size: 14px; line-height: 1.55; }
+.user-bubble { max-width: 88%; padding: 9px 13px; border-radius: 15px; border-bottom-right-radius: 5px; background: var(--surface-subtle); color: var(--text); font-size: 14px; line-height: 1.55; overflow-wrap: anywhere; }
 .user-annotations { margin-top: 6px; }
 .user-annotations > summary { display: inline-flex; align-items: center; gap: 5px; padding: 2px 9px; border: 1px solid color-mix(in srgb, var(--annotation) 35%, var(--border)); border-radius: 15px; border-bottom-right-radius: 5px; color: var(--annotation); background: color-mix(in srgb, var(--annotation) 8%, transparent); cursor: pointer; font-size: 11px; font-weight: 600; list-style: none; user-select: none; }
 .user-annotations > summary::-webkit-details-marker { display: none; }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -12,6 +12,8 @@ let fixtureSessionFile = ''
 let currentFixture: ReturnType<typeof createHermeticFixture> | undefined
 let actionableErrors: string[] = []
 
+const ISSUE_131_LONG_TOKEN = 'ReProductSkuController.getProductPoolDetail,ReProductSkuController.getProductPoolPriceWave'
+
 const instrumentedPages = new WeakSet<Page>()
 
 const attachDiagnostics = (target: Page) => {
@@ -109,7 +111,7 @@ function createHermeticFixture(activeSession = false): { userData: string; home:
   writeFileSync(ompSessionFile, [
     ompTitleSlot,
     JSON.stringify({ type: 'session', version: 3, id: '019fdf24-aaaa-7000-8000-000000000001', timestamp: '2026-02-01T00:00:00.000Z', cwd: canonicalProject }),
-    JSON.stringify({ type: 'message', id: 'omp-user', parentId: null, timestamp: '2026-02-01T00:00:01.000Z', message: { role: 'user', content: [{ type: 'text', text: 'OMP hermetic fixture' }], timestamp: 1774915201000 } }),
+    JSON.stringify({ type: 'message', id: 'omp-user', parentId: null, timestamp: '2026-02-01T00:00:01.000Z', message: { role: 'user', content: [{ type: 'text', text: `OMP hermetic fixture\n${ISSUE_131_LONG_TOKEN}` }], timestamp: 1774915201000 } }),
     JSON.stringify({ type: 'message', id: 'omp-assistant', parentId: 'omp-user', timestamp: '2026-02-01T00:00:02.000Z', message: { role: 'assistant', content: [{ type: 'text', text: 'OMP fixture reply.' }] } }),
     '',
   ].join('\n'))
@@ -890,6 +892,20 @@ test.describe('Prime Work desktop smoke', () => {
     await expect(page.getByRole('button', { name: 'Prime Work — switch harness' })).toBeVisible()
     await expect(page.locator('.session-row__title').filter({ hasText: 'Hermetic desktop fixture' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Scheduled' })).toBeVisible()
+  })
+
+  test('wraps an unbroken user-message token inside its chat bubble', async () => {
+    await page.getByRole('button', { name: 'Prime Work — switch harness' }).click()
+    await page.getByRole('menuitemradio', { name: /OMP Work/ }).click()
+    await page.locator('.session-row__title').filter({ hasText: 'OMP hermetic fixture' }).click()
+
+    const bubble = page.locator('.user-bubble').filter({ hasText: ISSUE_131_LONG_TOKEN })
+    await expect(bubble).toBeVisible()
+    const dimensions = await bubble.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }))
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth)
   })
 
   test('switches to Pi Work and lists the pi session catalog, then returns to Prime', async () => {


### PR DESCRIPTION
## Why

User messages containing a long continuous string can overflow beyond the chat bubble instead of wrapping within it. This is the layout failure reported in #131.

Closes #131.

## What Changed

- Allow user-bubble content to wrap at arbitrary points when no normal line-break opportunity exists.
- Add a hermetic Electron regression case based on the controller-name string in the report.

## Verification

- Before the fix, the regression measured a 372 px bubble with 639 px of horizontally overflowing content.
- After the fix, the same Electron test confirms the content remains within the bubble.
