### PR TITLE
fix(markdown): render RTL responses correctly

### DIFF
--- a/src/components/MarkdownText.tsx
+++ b/src/components/MarkdownText.tsx
@@ -30,11 +30,47 @@ function openMarkdownLink(event: MouseEvent<HTMLAnchorElement>, href?: string): 
 }
 
 const markdownPlugins = [remarkGfm]
+
+const RTL_STRONG_CHARACTER = /[\u05D0-\u05EA\u05F0-\u05F2\u0621-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0750-\u077F\u08A0-\u08FF\uFB1D-\uFB4F\uFB50-\uFDFF\uFE70-\uFEFC]/u
+const LTR_STRONG_CHARACTER = /\p{Letter}/u
+
+/**
+ * Removes Markdown code from direction detection: code often starts an
+ * otherwise RTL answer, but it must always retain its own LTR rendering.
+ */
+function proseForDirection(text: string): string {
+  let fence: string | undefined
+  return text.split('\n').map((line) => {
+    const opening = line.match(/^ {0,3}(`{3,}|~{3,})/)
+    if (!fence && opening) {
+      fence = opening[1]
+      return ''
+    }
+    if (fence) {
+      const closing = new RegExp(`^ {0,3}${fence[0]}{${fence.length},}\\s*$`)
+      if (closing.test(line)) fence = undefined
+      return ''
+    }
+    return line.replace(/`[^`\n]*`/g, '')
+  }).join('\n')
+}
+
+/** Find the first strong prose character, defaulting neutral-only text to LTR. */
+export function markdownTextDirection(text: string): 'ltr' | 'rtl' {
+  for (const character of proseForDirection(text)) {
+    if (RTL_STRONG_CHARACTER.test(character)) return 'rtl'
+    if (LTR_STRONG_CHARACTER.test(character)) return 'ltr'
+  }
+  return 'ltr'
+}
+
 const markdownComponents: Components = {
   a: ({ node: _node, href, children, ...props }) => href && (/^(https?:|mailto:|#)/i.test(href))
-    ? <a {...props} href={href} rel="noreferrer" onClick={(event) => openMarkdownLink(event, href)}>{children}</a>
+    ? <a {...props} href={href} rel="noreferrer" onClick={(event) => openMarkdownLink(event, href)}><bdi>{children}</bdi></a>
     : <span className="markdown-link-unsupported" title={href ? `Project-relative link: ${href}` : undefined}>{children}</span>,
+  code: ({ node: _node, children, ...props }) => <code {...props} dir="ltr">{children}</code>,
   img: ({ alt }) => <span className="markdown-image-placeholder">[Image: {alt || 'attachment'}]</span>,
+  pre: ({ node: _node, children, ...props }) => <pre {...props} dir="ltr">{children}</pre>,
 }
 
 export const STREAMING_PARSE_INTERVAL_MS = 100
@@ -105,5 +141,5 @@ export const MarkdownText = memo(function MarkdownText({ text, streaming = false
     () => <ReactMarkdown remarkPlugins={markdownPlugins} skipHtml components={markdownComponents}>{parsedText}</ReactMarkdown>,
     [parsedText],
   )
-  return <div className="prose">{markdown}</div>
+  return <div className="prose" dir={markdownTextDirection(parsedText)}>{markdown}</div>
 })

--- a/src/styles/transcript.css
+++ b/src/styles/transcript.css
@@ -46,9 +46,10 @@
 .prose li + li { margin-top: 3px; }
 .prose blockquote { padding-left: 11px; border-left: 3px solid var(--border-strong); color: var(--text-secondary); }
 .prose a { color: var(--annotation); text-decoration: underline; text-underline-offset: 2px; }
-.prose code { padding: 1px 4px; border: 1px solid var(--border); border-radius: 4px; background: var(--surface-subtle); font-size: .9em; }
-.prose pre { max-width: 100%; padding: 11px 13px; overflow: auto; border: 1px solid var(--border); border-radius: 8px; background: var(--canvas); font-size: 12px; line-height: 1.55; }
+.prose code { padding: 1px 4px; border: 1px solid var(--border); border-radius: 4px; direction: ltr; unicode-bidi: isolate; background: var(--surface-subtle); font-size: .9em; }
+.prose pre { max-width: 100%; padding: 11px 13px; overflow: auto; border: 1px solid var(--border); border-radius: 8px; direction: ltr; unicode-bidi: isolate; background: var(--canvas); font-size: 12px; line-height: 1.55; text-align: left; }
 .prose pre code { padding: 0; border: 0; background: transparent; font-size: inherit; white-space: pre; overflow-wrap: normal; }
+.prose a > bdi { unicode-bidi: isolate; }
 .prose table { display: block; max-width: 100%; overflow-x: auto; border-collapse: collapse; }
 .prose th, .prose td { padding: 5px 8px; border: 1px solid var(--border); text-align: left; }
 .prose th { background: var(--surface-subtle); font-weight: 600; }

--- a/tests/backend/markdown.test.ts
+++ b/tests/backend/markdown.test.ts
@@ -12,7 +12,7 @@ describe('chat Markdown rendering', () => {
     expect(html).toContain('<h2>Result</h2>')
     expect(html).toContain('<strong>Done</strong>')
     expect(html).toContain('<ul>')
-    expect(html).toContain('<pre><code class="language-ts">')
+    expect(html).toContain('<pre dir="ltr"><code class="language-ts" dir="ltr">')
     expect(html).toContain('<table>')
   })
 

--- a/tests/frontend/markdown-direction.test.tsx
+++ b/tests/frontend/markdown-direction.test.tsx
@@ -1,0 +1,26 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { MarkdownText, markdownTextDirection } from '../../src/components/MarkdownText'
+
+describe('Markdown text direction', () => {
+  it('finds the first strong prose character while ignoring Markdown code', () => {
+    expect(markdownTextDirection('`src/App.tsx` سپس ادامه دهید.')).toBe('rtl')
+    expect(markdownTextDirection('```ts\nconst answer = true\n```\n\nسلام دنیا')).toBe('rtl')
+    expect(markdownTextDirection('مرحبا بالعالم')).toBe('rtl')
+    expect(markdownTextDirection('שלום עולם')).toBe('rtl')
+    expect(markdownTextDirection('Read this: سلام')).toBe('ltr')
+    expect(markdownTextDirection('۱۲۳')).toBe('ltr')
+  })
+
+  it('renders RTL prose with isolated LTR code, URLs, and code blocks', () => {
+    const html = renderToStaticMarkup(createElement(MarkdownText, {
+      text: 'مسیر `src/App.tsx` و https://example.com را بررسی کنید.\n\n```ts\nconst answer = true\n```',
+    }))
+
+    expect(html).toContain('class="prose" dir="rtl"')
+    expect(html).toContain('<code dir="ltr">src/App.tsx</code>')
+    expect(html).toContain('<bdi>https://example.com</bdi>')
+    expect(html).toContain('<pre dir="ltr"><code class="language-ts" dir="ltr">const answer = true')
+  })
+})


### PR DESCRIPTION
## Why

AI replies in Persian, Arabic, and Hebrew were rendered as LTR text, which made mixed-direction punctuation and embedded code hard to read. Thanks to @Recoba86 for reporting and documenting this in #144.

## What Changed

- Infer response direction from the first strong prose character, while excluding inline and fenced Markdown code from that decision.
- Render model Markdown with an explicit direction, isolate links and inline code, and keep fenced code blocks LTR.
- Cover Persian, Arabic, Hebrew, inline paths, URLs, and code fences in renderer tests.

Fixes #144.

## Verification

`npm test -- --run tests/frontend/markdown-direction.test.tsx tests/frontend/markdown-streaming.test.ts tests/backend/markdown.test.ts` — 5 tests passed, including rendered RTL prose with an inline path, URL, and TypeScript code fence.
