### PR TITLE
fix(transcript): keep final reports visible

### DIFF
--- a/src/components/transcript/messages.tsx
+++ b/src/components/transcript/messages.tsx
@@ -55,6 +55,39 @@ function renderNarrativeWithActivity(parts: MessagePart[], keyPrefix: string, sh
   )
 }
 
+function isNarrative(part: MessagePart): part is Extract<MessagePart, { type: 'text' | 'image' }> {
+  return part.type === 'text' || part.type === 'image'
+}
+
+/**
+ * Completed turns can receive lightweight activity after their final answer.
+ * Anchor the visible tail at the most substantial narrative run, preferring
+ * the later run on ties, so everything after that anchor remains in order and
+ * a short trailing note cannot bury a longer deliverable in the work rail.
+ */
+function primaryNarrativeStart(parts: MessagePart[], start: number): number {
+  let bestStart = -1
+  let bestScore = 0
+  for (let index = start; index < parts.length;) {
+    if (!isNarrative(parts[index])) {
+      index += 1
+      continue
+    }
+    const runStart = index
+    let score = 0
+    while (index < parts.length && isNarrative(parts[index])) {
+      const part = parts[index]
+      score += part.type === 'text' ? part.text.trim().length : 1
+      index += 1
+    }
+    if (score > 0 && score >= bestScore) {
+      bestStart = runStart
+      bestScore = score
+    }
+  }
+  return bestStart
+}
+
 function messageText(message: TranscriptMessage): string {
   return message.parts
     .filter((part) => part.type === 'text')
@@ -107,18 +140,15 @@ function AssistantHarnessMark({ harness, size = 24 }: { harness: HarnessId; size
 export const AssistantMessage = memo(
   function AssistantMessage({ message, harness = 'prime', showReasoning, showTools }: { message: TranscriptMessage; harness?: HarnessId; showReasoning: boolean; showTools: boolean }) {
     const isActivity = (part: MessagePart) => part.type === 'thinking' || part.type === 'toolCall' || part.type === 'toolResult' || part.type === 'agentMessage' || part.type === 'compaction'
-    const isCoreActivity = (part: MessagePart) => part.type === 'thinking' || part.type === 'toolCall' || part.type === 'toolResult' || part.type === 'compaction'
     const firstActivity = message.parts.findIndex(isActivity)
     let lastActivity = -1
-    let lastCoreActivity = -1
     for (let index = message.parts.length - 1; index >= 0; index -= 1) {
-      if (lastActivity < 0 && isActivity(message.parts[index])) lastActivity = index
-      if (isCoreActivity(message.parts[index])) {
-        lastCoreActivity = index
+      if (isActivity(message.parts[index])) {
+        lastActivity = index
         break
       }
     }
-    const finalNarrative = lastCoreActivity < 0 ? -1 : message.parts.findIndex((part, index) => index > lastCoreActivity && (part.type === 'text' || part.type === 'image'))
+    const finalNarrative = firstActivity < 0 ? -1 : primaryNarrativeStart(message.parts, firstActivity + 1)
     const workEnd = finalNarrative >= 0 ? finalNarrative : lastActivity + 1
     const before = firstActivity < 0 ? message.parts : message.parts.slice(0, firstActivity)
     const work = firstActivity < 0 ? [] : message.parts.slice(firstActivity, workEnd)

--- a/tests/frontend/timeline-part-identity.test.tsx
+++ b/tests/frontend/timeline-part-identity.test.tsx
@@ -3,6 +3,7 @@
 import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AssistantMessage } from '../../src/components/transcript/messages'
 import { WorkTimeline } from '../../src/components/transcript/timeline'
 import { replayPrimeEvents } from '../../src/lib/events'
 import type { TranscriptMessage } from '../../src/types/api'
@@ -29,6 +30,30 @@ function renderTimeline(message: TranscriptMessage): void {
 }
 
 describe('timeline part identity', () => {
+  it('copies the promoted final report when reasoning trails it', async () => {
+    const writeText = vi.fn(async () => undefined)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    act(() => {
+      root.render(createElement(AssistantMessage, {
+        message: {
+          id: 'copy-final-report', role: 'assistant', completedAt: 2_000,
+          parts: [
+            { type: 'thinking', text: 'Earlier reasoning.' },
+            { type: 'text', text: 'Primary final report.' },
+            { type: 'thinking', text: 'Trailing reasoning.' },
+          ],
+        },
+        showReasoning: true,
+        showTools: true,
+      }))
+    })
+
+    const copy = container.querySelector('[aria-label="Copy assistant message"]') as HTMLButtonElement
+    expect(copy).not.toBeNull()
+    await act(async () => { copy.click() })
+    expect(writeText).toHaveBeenCalledWith('Primary final report.')
+  })
+
   it('only shows the tool copy action after expanding and copies its contents', async () => {
     const writeText = vi.fn(async () => undefined)
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })

--- a/tests/frontend/transcript-rendering.test.ts
+++ b/tests/frontend/transcript-rendering.test.ts
@@ -288,6 +288,46 @@ describe('transcript rendering', () => {
     expect(html).toContain('aria-label="Copy assistant message"')
   })
 
+  it('keeps a final report visible when reasoning arrives after it', () => {
+    const html = render([{
+      id: 'trailing-reasoning',
+      role: 'assistant',
+      timestamp: 1_000,
+      completedAt: 2_000,
+      parts: [
+        { type: 'thinking', text: 'Earlier reasoning.' },
+        { type: 'text', text: 'The primary final report stays visible.' },
+        { type: 'thinking', text: 'Trailing lightweight reasoning.' },
+      ],
+    }])
+
+    expect(html).toContain('Worked for 1s')
+    expect(html).toContain('The primary final report stays visible.')
+    expect(html).toContain('Trailing lightweight reasoning.')
+    expect(html).not.toContain('Earlier reasoning.')
+    expect(html).toContain('aria-label="Copy assistant message"')
+  })
+
+  it('promotes a substantive report ahead of trailing activity and an incidental note', () => {
+    const html = render([{
+      id: 'trailing-tool-and-note',
+      role: 'assistant',
+      timestamp: 1_000,
+      completedAt: 2_000,
+      parts: [
+        { type: 'thinking', text: 'Earlier reasoning.' },
+        { type: 'text', text: 'This is the complete substantive report with the requested conclusions and evidence.' },
+        { type: 'toolCall', id: 'cleanup', name: 'update_todo' },
+        { type: 'toolResult', name: 'update_todo', text: 'done' },
+        { type: 'text', text: 'Cleanup complete.' },
+      ],
+    }])
+
+    expect(html).toContain('This is the complete substantive report with the requested conclusions and evidence.')
+    expect(html).toContain('Cleanup complete.')
+    expect(html).toContain('update_todo')
+  })
+
   it('nests agent messages in active work without opening their contents', () => {
     const html = render([{
       id: 'active-agent-message',


### PR DESCRIPTION
## Why

Completed assistant turns can receive reasoning, tool activity, or a short status note after their substantive final report. The transcript previously anchored visible narrative strictly after the last core activity, which could place the report inside the collapsed `Worked for` disclosure and omit it from the message Copy action.

Closes #146.

## What Changed

- anchor the completed message's visible tail at its most substantial contiguous narrative run, preferring the later run on ties
- preserve the ordering of later activity and notes while keeping the primary report visible and copyable
- cover trailing reasoning, trailing tool activity plus an incidental note, and the actual clipboard payload

## Verification

- a completed `[thinking, report, thinking]` transcript now renders the report outside the collapsed work disclosure
- a longer report remains visible when followed by tool cleanup and a short note
- the assistant Copy action writes the promoted report text to the clipboard

## Credit

Reported and root-caused by @Recoba86 in #146. Thank you for tracing the failure to the transcript partitioning logic and documenting the affected Copy behavior.
