### PR TITLE
chore: release GooeyPi 1.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gooeypi",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gooeypi",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gooeypi",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "private": true,
   "description": "A desktop workspace for Pi, OMP, and Prime Agent",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Why

Publish the next GooeyPi version containing the changes merged since v1.1.13.

## What Changed

- Bump package metadata to 1.1.14 in package.json and package-lock.json.
- Release workflow will build macOS, Linux, and unsigned Windows packages from the protected main commit.

## Verification

- npm run release:verify:package
- npm run test:coverage (host-equivalent permissions; 150 files passed, 1692 tests passed, 1 skipped)