### PR TITLE
feat(transcript): grow the conversation column on wide panes

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -52,6 +52,9 @@
   --terminal-bright-cyan: #177f83;
   --terminal-bright-white: #20201e;
   --shadow-popover: 0 10px 30px rgba(0, 0, 0, .12);
+  /* Shared transcript column measure: grows with the pane from the 760px
+     reading minimum, capped so prose stays readable on very wide monitors. */
+  --transcript-measure: max(760px, min(85%, 1240px));
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
   font-size: 13px;
   font-synthesis: none;

--- a/src/styles/composer.css
+++ b/src/styles/composer.css
@@ -1,5 +1,5 @@
 /* Composer */
-.composer-wrap { position: absolute; z-index: 10; left: 24px; right: 24px; bottom: 13px; width: min(calc(100% - 48px), 760px); margin: 0 auto; }
+.composer-wrap { position: absolute; z-index: 10; left: 24px; right: 24px; bottom: 13px; width: min(calc(100% - 48px), var(--transcript-measure)); margin: 0 auto; }
 .composer { position: relative; min-height: 104px; display: flex; flex-direction: column; padding: 7px; border: 1px solid var(--border-strong); border-radius: 14px; background: var(--surface-raised); box-shadow: 0 1px 3px rgba(0,0,0,.06); }
 .composer-queue { display: grid; gap: 5px; margin: 0 0 8px; padding: 7px 8px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-raised); box-shadow: 0 3px 12px color-mix(in srgb, #000 8%, transparent); }
 .composer-queue__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--text-tertiary); font-size: 10.5px; font-weight: 620; letter-spacing: .01em; }

--- a/src/styles/transcript.css
+++ b/src/styles/transcript.css
@@ -4,9 +4,9 @@
 .transcript.has-docked-changes { padding-bottom: 250px; }
 .transcript.has-queued-messages { padding-bottom: 325px; }
 .transcript.has-docked-changes.has-queued-messages { padding-bottom: 405px; }
-.transcript-changes-pin { position: absolute; z-index: 9; left: 24px; right: 24px; bottom: 137px; width: min(calc(100% - 48px), 760px); margin: 0 auto; }
+.transcript-changes-pin { position: absolute; z-index: 9; left: 24px; right: 24px; bottom: 137px; width: min(calc(100% - 48px), var(--transcript-measure)); margin: 0 auto; }
 .transcript-changes-pin .changes-card { margin: 0; box-shadow: 0 4px 18px color-mix(in srgb, #000 12%, transparent); }
-.transcript__inner { width: min(100%, 760px); min-height: 100%; margin: 0 auto; padding: 0 24px; }
+.transcript__inner { width: min(100%, var(--transcript-measure)); min-height: 100%; margin: 0 auto; padding: 0 24px; }
 .transcript__show-earlier { min-height: 30px; display: block; margin: 16px auto 26px; padding: 0 11px; border: 1px solid var(--border); border-radius: 7px; color: var(--text-secondary); background: var(--surface-raised); font-size: 11px; }
 .transcript__show-earlier:hover { color: var(--text); background: var(--surface-hover); }
 .transcript-loading { display: flex; align-items: center; justify-content: center; gap: 7px; padding: 40px; color: var(--text-tertiary); }

--- a/src/styles/workbench.css
+++ b/src/styles/workbench.css
@@ -18,7 +18,7 @@
 .session-workspace { display: flex; height: 100%; min-height: 0; min-width: 0; }
 .conversation-column { position: relative; display: flex; min-height: 0; min-width: 0; flex: 1 1 auto; flex-direction: column; }
 .conversation-pane { position: relative; min-width: 360px; min-height: 0; flex: 1 1 auto; background: var(--canvas); overflow: hidden; container-type: inline-size; }
-.conversation-bottom-dock { position: absolute; z-index: 10; right: 24px; bottom: 13px; left: 24px; width: min(calc(100% - 48px), 760px); margin: 0 auto; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
+.conversation-bottom-dock { position: absolute; z-index: 10; right: 24px; bottom: 13px; left: 24px; width: min(calc(100% - 48px), var(--transcript-measure)); margin: 0 auto; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
 .conversation-bottom-dock > * { pointer-events: auto; }
 .conversation-bottom-dock .composer-wrap { position: relative; inset: auto; width: 100%; margin: 0; }
 .conversation-bottom-dock .changes-card { margin: 0; box-shadow: 0 4px 18px color-mix(in srgb, #000 12%, transparent); }


### PR DESCRIPTION
Fixes #151.

## Problem

The conversation column was hard-capped at 760px in four places — the transcript itself, the composer, the bottom dock, and the pinned-changes card — so wide windows showed a narrow centered column with large fixed dead margins, and markdown tables in agent reports rendered with heavy horizontal scrolling even when hundreds of pixels were free.

## Change

A single shared token drives all four surfaces so their edges stay perfectly aligned while the column grows:

```css
/* base.css */
--transcript-measure: max(760px, min(85%, 1240px));
```

- `.transcript__inner` → `width: min(100%, var(--transcript-measure))`
- `.composer-wrap`, `.conversation-bottom-dock`, `.transcript-changes-pin` → `width: min(calc(100% - 48px), var(--transcript-measure))`

Resulting behavior (pane = conversation-pane width):

| Pane width | Column width |
|---|---|
| ≤ ~894px | 760px — unchanged from today |
| 894px – 1459px | 85% of pane (grows fluidly) |
| ≥ 1459px | 1240px ceiling |

The ceiling keeps prose at a comfortable reading measure on very wide monitors while still using roughly twice today's width; side margins shrink proportionally since the column stays centered. Markdown tables and code blocks benefit directly from the extra width as the issue suggests — they are already scroll-contained. Narrow layouts and `responsive.css` behavior are untouched (below the fluid threshold everything resolves to exactly today's 760px).

## Notes

- Pure CSS: jsdom can't assert layout, so verification is the standard suite + build plus this behavior table; a quick visual pass on a wide display before merge would confirm the feel.
- Kept scope minimal per the issue's primary suggestion. If maintainers want it user-adjustable later (the issue's alternative), a settings knob can override the token per workspace without touching these rules again.

## Testing

- All 481 frontend tests pass; typecheck clean; biome lint/format clean.
- `npm run build:bundle` + bundle size gates pass (renderer JS/CSS total is well under budget).
