### PR TITLE
fix(composer): dispatch compact RPC command for /compact slash command

### DIFF
--- a/src/hooks/useWorkspaceActions.ts
+++ b/src/hooks/useWorkspaceActions.ts
@@ -99,6 +99,16 @@ export async function titleStartedSession({ bridge, harness, runtimeId, sessionF
   await indexStartedSession({ bridge, harness, sessionFile, setSessions, fallbackTitle: title, isCurrent }).catch(() => undefined)
 }
 
+export function parseCompactCommand(prompt: string): { customInstructions?: string } | undefined {
+  const trimmed = prompt.trim()
+  if (trimmed === '/compact') return {}
+  if (trimmed.startsWith('/compact ')) {
+    const customInstructions = trimmed.slice(9).trim()
+    return customInstructions ? { customInstructions } : {}
+  }
+  return undefined
+}
+
 export function parseMcpCommand(prompt: string, harness: HarnessId): McpCommand | undefined {
   const value = prompt.trim()
   if (harness === 'prime' && value === '/mcp') return { type: 'open' }
@@ -259,6 +269,7 @@ export function createWorkspaceActions(getDeps: () => WorkspaceActionsDeps) {
   ) => {
     const { bridge, sessions, workspace, provider, settingsState, submissionAdmissionRef, demoTimerRef, setSessions, setSubmitting, setView, setToast, reportError } = getDeps()
     const commandHarness = workspace.workspaceRef?.current?.project?.harness ?? settingsState.settings.activeHarness
+    const compactCommand = parseCompactCommand(prompt)
     const mcpCommand = parseMcpCommand(prompt, commandHarness)
     if (mcpCommand?.type === 'open' && images.length === 0) {
       setView('plugins')
@@ -419,7 +430,13 @@ export function createWorkspaceActions(getDeps: () => WorkspaceActionsDeps) {
           throw new Error(`${HARNESS_AGENT_NAMES[activeHarness]} returned a runtime for a different workspace or session.`)
         }
         workspace.attachRuntime(activeRuntime, generation)
-        if (activeRuntime.isStreaming) {
+        if (compactCommand) {
+          await bridge.agent.command(activeRuntime.runtimeId, {
+            type: 'compact',
+            ...(compactCommand.customInstructions ? { customInstructions: compactCommand.customInstructions } : {}),
+          })
+          completeQueuedFlush()
+        } else if (activeRuntime.isStreaming) {
           // Follow-ups are daemon-owned. Steers get a renderer-only pending
           // row so pickup can move them into history without redelivery.
           if (intent === 'steer') queuedPromptId = workspace.queuePrompt(prompt, intent, userMessage.parts, sentAt)

--- a/tests/unit/compact-command.test.ts
+++ b/tests/unit/compact-command.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { parseCompactCommand } from '../../src/hooks/useWorkspaceActions'
+
+describe('parseCompactCommand', () => {
+  it('parses bare /compact command', () => {
+    expect(parseCompactCommand('/compact')).toEqual({})
+    expect(parseCompactCommand('  /compact  ')).toEqual({})
+  })
+
+  it('parses /compact with custom instructions', () => {
+    expect(parseCompactCommand('/compact focus on auth')).toEqual({ customInstructions: 'focus on auth' })
+    expect(parseCompactCommand('/compact   keep current plan and tests  ')).toEqual({ customInstructions: 'keep current plan and tests' })
+  })
+
+  it('returns undefined for non-compact prompts or prefix matches', () => {
+    expect(parseCompactCommand('/compacting')).toBeUndefined()
+    expect(parseCompactCommand('please /compact')).toBeUndefined()
+    expect(parseCompactCommand('/review')).toBeUndefined()
+    expect(parseCompactCommand('hello world')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Resolves #182

### Summary
Fixes manual `/compact` submission in Composer by intercepting `/compact` (and optional custom instructions) in `sendPrompt` and executing the existing `{ type: 'compact' }` RPC command instead of delivering it as a user text prompt.

### Changes
- Added `parseCompactCommand` helper in `src/hooks/useWorkspaceActions.ts` supporting both bare `/compact` and `/compact <customInstructions>`.
- Updated `sendPrompt` to dispatch `{ type: 'compact', ...(customInstructions ? { customInstructions } : {}) }` to the runtime.
- Added comprehensive unit tests in `tests/unit/compact-command.test.ts`.

### Verification
- `npm run typecheck` passed cleanly across all tsconfigs.
- `npm run check` (biome lint + format) passed with 0 errors.
- `npx vitest run tests/unit/compact-command.test.ts` passed.