### PR TITLE
fix(models): isolate and restore model and effort selection per session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,17 +191,18 @@ export default function App() {
       lastSelectedModels: { ...settingsState.settings.lastSelectedModels, [activeHarness]: modelKey },
     })
   }, [activeHarness, settingsState.settings.lastSelectedModels, settingsState.updateSettings])
+  const activeSession = useMemo(() => sessions.find((session) => session.id === workspace.activeSessionId), [sessions, workspace.activeSessionId])
   const provider = useProviderCatalog({
     bridge,
     ready: settingsState.initialized,
     harness: activeHarness,
     runtime: workspace.runtime,
+    activeSession,
     lastSelectedModel: settingsState.settings.lastSelectedModels[activeHarness],
     rememberModel: rememberSelectedModel,
     syncRuntime: syncProviderRuntime,
     reportError,
   })
-  const activeSession = useMemo(() => sessions.find((session) => session.id === workspace.activeSessionId), [sessions, workspace.activeSessionId])
   const activeProject = useMemo(() => findProjectForSession(projects, activeSession)
     ?? projects.find((project) => project.id === workspace.activeProjectId)
     ?? projects[0], [projects, activeSession, workspace.activeProjectId])

--- a/src/hooks/useProviderCatalog.ts
+++ b/src/hooks/useProviderCatalog.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import type { HarnessId, PrimeModelCatalog, PrimeModelDescriptor, PrimeThinkingLevel, PrimeWorkApi, ProviderAuthEvent, RuntimeInfo } from '@/types/api'
+import type { HarnessId, PrimeModelCatalog, PrimeModelDescriptor, PrimeThinkingLevel, PrimeWorkApi, ProviderAuthEvent, RuntimeInfo, SessionRecord } from '@/types/api'
 
 type ActiveProviderAuthEvent = Exclude<ProviderAuthEvent, { type: 'cancelled' }>
 
@@ -24,6 +24,8 @@ interface UseProviderCatalogOptions {
   /** Harness whose model catalog is shown; catalogs are cached per harness. */
   harness?: HarnessId
   runtime: RuntimeInfo | null
+  /** Active session metadata if available. */
+  activeSession?: SessionRecord
   /** Persisted per-harness model preference. */
   lastSelectedModel?: string
   rememberModel?(modelKey: string): void
@@ -31,7 +33,7 @@ interface UseProviderCatalogOptions {
   reportError(error: unknown): void
 }
 
-export function useProviderCatalog({ bridge, ready = true, harness = 'prime', runtime, lastSelectedModel = '', rememberModel, syncRuntime, reportError }: UseProviderCatalogOptions) {
+export function useProviderCatalog({ bridge, ready = true, harness = 'prime', runtime, activeSession, lastSelectedModel = '', rememberModel, syncRuntime, reportError }: UseProviderCatalogOptions) {
   const [model, setModel] = useState('')
   const [effort, setEffort] = useState<PrimeThinkingLevel>('medium')
   const [fast, setFast] = useState(false)
@@ -99,10 +101,15 @@ export function useProviderCatalog({ bridge, ready = true, harness = 'prime', ru
     nextCatalog?.models.find((candidate) => candidate.enabled !== false && candidate.available)
   ), [])
 
-  const fallbackModel = useCallback((nextCatalog: PrimeModelCatalog | null | undefined) => (
-    nextCatalog?.models.find((candidate) => candidate.key === lastSelectedModel && candidate.enabled !== false && candidate.available)
+  const fallbackModel = useCallback((nextCatalog: PrimeModelCatalog | null | undefined) => {
+    if (activeSession?.provider && activeSession.model && nextCatalog) {
+      const sessionModel = nextCatalog.models.find((candidate) => candidate.provider === activeSession.provider && (candidate.id === activeSession.model || candidate.key === activeSession.model) && candidate.enabled !== false && candidate.available)
+        ?? nextCatalog.models.find((candidate) => candidate.id === activeSession.model && candidate.enabled !== false && candidate.available)
+      if (sessionModel) return sessionModel
+    }
+    return nextCatalog?.models.find((candidate) => candidate.key === lastSelectedModel && candidate.enabled !== false && candidate.available)
       ?? firstUsableModel(nextCatalog)
-  ), [firstUsableModel, lastSelectedModel])
+  }, [activeSession?.model, activeSession?.provider, firstUsableModel, lastSelectedModel])
 
   const selectedModel = useMemo<PrimeModelDescriptor | undefined>(() => {
     return catalog?.models.find((candidate) => candidate.key === model && candidate.enabled !== false && candidate.available)
@@ -160,15 +167,37 @@ export function useProviderCatalog({ bridge, ready = true, harness = 'prime', ru
     })
   }, [bridge, refresh, reportError])
 
+  const activeSessionIdRef = useRef(activeSession?.id)
   useEffect(() => {
-    if (!runtime?.model?.provider || !runtime.model.id || !catalog) return
-    const effectiveModel = catalog.models.find((candidate) => candidate.provider === runtime.model?.provider && candidate.id === runtime.model?.id && candidate.enabled !== false && candidate.available)
-    if (effectiveModel) {
-      updateModel(effectiveModel.key)
-      rememberSelectionRef.current(effectiveModel.key)
+    if (!catalog) return
+    const sessionChanged = activeSessionIdRef.current !== activeSession?.id
+    activeSessionIdRef.current = activeSession?.id
+
+    // 1. If active live runtime has a model, sync to it
+    if (runtime?.model?.provider && runtime.model.id) {
+      const runtimeModel = catalog.models.find((candidate) => candidate.provider === runtime.model?.provider && candidate.id === runtime.model?.id && candidate.enabled !== false && candidate.available)
+      if (runtimeModel) {
+        if (modelRef.current !== runtimeModel.key) updateModel(runtimeModel.key)
+        rememberSelectionRef.current(runtimeModel.key)
+      }
+      if (runtime.thinkingLevel && runtimeModel?.availableThinkingLevels.includes(runtime.thinkingLevel as PrimeThinkingLevel)) {
+        if (effortRef.current !== runtime.thinkingLevel) updateEffort(runtime.thinkingLevel as PrimeThinkingLevel)
+      }
+      return
     }
-    if (runtime.thinkingLevel && effectiveModel?.availableThinkingLevels.includes(runtime.thinkingLevel as PrimeThinkingLevel)) updateEffort(runtime.thinkingLevel as PrimeThinkingLevel)
-  }, [catalog, runtime?.model?.id, runtime?.model?.provider, runtime?.thinkingLevel, updateEffort, updateModel])
+
+    // 2. If active selected session has a persisted model/provider, sync on session switch or initial load
+    if (activeSession?.provider && activeSession.model && sessionChanged) {
+      const sessionModel = catalog.models.find((candidate) => candidate.provider === activeSession.provider && (candidate.id === activeSession.model || candidate.key === activeSession.model) && candidate.enabled !== false && candidate.available)
+        ?? catalog.models.find((candidate) => candidate.id === activeSession.model && candidate.enabled !== false && candidate.available)
+      if (sessionModel && modelRef.current !== sessionModel.key) {
+        updateModel(sessionModel.key)
+      }
+      if (activeSession.thinkingLevel && sessionModel?.availableThinkingLevels.includes(activeSession.thinkingLevel as PrimeThinkingLevel)) {
+        if (effortRef.current !== activeSession.thinkingLevel) updateEffort(activeSession.thinkingLevel as PrimeThinkingLevel)
+      }
+    }
+  }, [activeSession?.id, catalog, runtime?.model?.id, runtime?.model?.provider, runtime?.thinkingLevel, updateEffort, updateModel])
 
   // Scoped to the runtime's reported tier so a catalog refresh cannot revert
   // an optimistic fast-mode toggle that the runtime has not confirmed yet.

--- a/tests/frontend/harness-switching.test.tsx
+++ b/tests/frontend/harness-switching.test.tsx
@@ -487,27 +487,40 @@ describe('provider catalog per harness', () => {
     expect(state.model).toBe('openai-codex/gpt-5.6')
   })
 
-  it('restores a usable remembered model and replaces a stale preference with the first usable model', async () => {
+  it('syncs model and thinking level from active session metadata when runtime has no live model', async () => {
     const alternate = { ...primeCatalog.models[0], key: 'openai-codex/gpt-5.5', id: 'gpt-5.5', name: 'GPT-5.5' }
     const catalog = { ...primeCatalog, models: [primeCatalog.models[0], alternate] }
     const bridge = {
       providers: { catalog: vi.fn(async () => catalog), onAuthEvent: vi.fn().mockReturnValue(() => undefined) },
     } as unknown as PrimeWorkApi
-    const rememberModel = vi.fn()
     const reportError = vi.fn()
     let state!: ReturnType<typeof useProviderCatalog>
-    function CatalogProbe({ lastSelectedModel }: { lastSelectedModel: string }) {
-      state = useProviderCatalog({ bridge, harness: 'prime', runtime: null, lastSelectedModel, rememberModel, syncRuntime: async () => undefined, reportError })
+    function CatalogProbe({ activeSession }: { activeSession?: SessionRecord }) {
+      state = useProviderCatalog({ bridge, harness: 'prime', runtime: null, activeSession, syncRuntime: async () => undefined, reportError })
       return <Probe />
     }
 
-    await act(async () => { root.render(<CatalogProbe lastSelectedModel={alternate.key} />); await Promise.resolve() })
-    expect(state.model).toBe(alternate.key)
-    expect(rememberModel).not.toHaveBeenCalled()
+    const sessionA: SessionRecord = {
+      ...primeSession,
+      id: 'session-a',
+      provider: 'openai-codex',
+      model: 'gpt-5.5',
+      thinkingLevel: 'low',
+    }
 
-    await act(async () => { root.render(<CatalogProbe key="stale-preference" lastSelectedModel="missing/model" />); await Promise.resolve() })
+    const sessionB: SessionRecord = {
+      ...primeSession,
+      id: 'session-b',
+      provider: 'openai-codex',
+      model: primeCatalog.models[0].id,
+      thinkingLevel: 'high',
+    }
+
+    await act(async () => { root.render(<CatalogProbe activeSession={sessionA} />); await Promise.resolve() })
+    expect(state.model).toBe('openai-codex/gpt-5.5')
+
+    await act(async () => { root.render(<CatalogProbe activeSession={sessionB} />); await Promise.resolve() })
     expect(state.model).toBe(primeCatalog.models[0].key)
-    expect(rememberModel).toHaveBeenLastCalledWith(primeCatalog.models[0].key)
   })
 })
 


### PR DESCRIPTION
Resolves #180

### Summary
Fixes global model selection bleed across session tabs. When switching between session tabs, GooeyPi now checks the active session's persisted model, provider, and thinking level from session metadata and synchronizes the active model picker state accordingly.

### Changes
- Pass `activeSession` into `useProviderCatalog`.
- In `fallbackModel`, prefer the active session's persisted `provider`/`model` over the global fallback when available in the catalog.
- Added session-switch synchronization in `useProviderCatalog` to update the active model and thinking level whenever switching to a session that already has a configured model.
- Added unit test in `tests/frontend/harness-switching.test.tsx` verifying model and effort scoping across session switches.

### Verification
- `npm run typecheck` passed cleanly across all 5 tsconfigs.
- `npm run check` (biome lint + format) passed with 0 errors.
- `npx vitest run tests/frontend/harness-switching.test.tsx` passed.