### PR TITLE
Add Cloud Agent environment and GooeyPi verification skill

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "GooeyPi",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Cloud Agent install phase for GooeyPi.
+#
+# Idempotent bootstrap that prepares a checked-out working tree so a Cloud
+# Agent can lint, type-check, test, build, and run the Electron desktop app.
+# Runs on Cursor's default Ubuntu base image (which already provides nvm, sudo,
+# build-essential, python3, xvfb and ffmpeg).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# --- Node toolchain (pinned by .nvmrc + package.json#engines) ---------------
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh"
+nvm install >/dev/null        # reads .nvmrc (24.15.0); no-op once installed
+nvm use >/dev/null
+nvm alias default "$(cat .nvmrc)" >/dev/null
+
+# --- System libraries to run/build the Electron app and its headless -------
+# --- (xvfb) Playwright Electron e2e suite ----------------------------------
+# apt is only reachable when sudo is available; skip cleanly otherwise so the
+# script still works on images where these libraries are already present.
+if command -v sudo >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+    xvfb \
+    libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 libcups2t64 libdrm2 \
+    libgbm1 libgtk-3-0t64 libasound2t64 libxkbcommon0 libpango-1.0-0 \
+    libcairo2 libxcomposite1 libxdamage1 libxrandr2 libxfixes3 libxext6 \
+    libxi6 libatspi2.0-0t64 libxshmfence1 libx11-xcb1 >/dev/null
+fi
+
+# --- Repository-pinned npm (package.json#packageManager) -------------------
+# Installs the exact npm floor before dependencies; the repo rejects older npm.
+npm run toolchain:bootstrap
+
+# --- Project dependencies + native/Electron runtime ------------------------
+# `npm ci` runs the repo postinstall (electron platform download + native
+# dependency rebuild). node-pty is rebuilt for Electron; zeromq/koffi ship
+# vendored prebuilt binaries, so npm 12's default script blocking is fine.
+npm ci
+
+echo "GooeyPi Cloud Agent install complete: node $(node -v), npm $(npm -v)."

--- a/.cursor/skills/verify-gooeypi/SKILL.md
+++ b/.cursor/skills/verify-gooeypi/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: verify-gooeypi
+description: Launch and drive the GooeyPi desktop (Electron) app to prove user-facing behavior — sidebar navigation, Settings, and Capabilities — capturing screenshots and ARIA snapshots. Reach for this when verifying a GooeyPi UI change or confirming the app still works end to end.
+---
+
+# Verify GooeyPi
+
+GooeyPi is a **desktop Electron app** — that window is the only surface a user
+touches (there is no user-facing web page, CLI, or API). This skill launches the
+built app in an isolated, disposable profile, drives one user-facing feature the
+way a person would, and captures evidence. The driver mirrors the repo's own
+Playwright Electron harness (`tests/e2e/app.spec.ts`) but runs as a standalone
+controller you can invoke directly.
+
+The maintained feature list lives in [`features/`](./features/README.md); read
+its index before driving, then use the matching feature file as the recipe.
+
+## Launch
+
+- **Build once.** The driver launches the built bundle (`package.json` `main` →
+  `out/main/index.js`). If it is missing, build it: `npm run build`. The driver
+  aborts with a clear message when the bundle is absent.
+- **Toolchain.** `node`/`npm` come from `nvm` (pinned `24.15.0` / `12.0.2`). If
+  `node -v` is not `v24.15.0`, select it first:
+  `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use >/dev/null`.
+- **Display.** The app needs an X display. On a headless machine prefix every
+  command with `xvfb-run -a` (e.g. `xvfb-run -a --server-args="-screen 0 1600x1000x24" ...`).
+- **Isolation.** Every drive launches its own app instance with a throwaway
+  `HOME` and Electron `--user-data-dir`, so it never reads or writes your real
+  `~/.prime` / `~/.omp` / `~/.pi` state and never drives an instance it did not
+  start. Readiness is `.app-shell[data-ready="true"]`. A fresh `HOME` has no
+  harness installed, so the driver first dismisses the `No Pi family harness
+  detected` modal (that modal makes the shell `inert`).
+- **Command.** `xvfb-run -a node .cursor/skills/verify-gooeypi/control.mjs drive <scenario> --out <dir>`
+
+## Doctor
+
+Answer "is this instance worth driving?" before anything else, or whenever the
+app looks wrong:
+
+```
+xvfb-run -a node .cursor/skills/verify-gooeypi/control.mjs doctor --out /tmp/gooeypi-verify/doctor
+```
+
+It launches the app, asserts `.app-shell[data-ready="true"]`, prints the window
+title (expect `GooeyPi`), and screenshots. A non-zero exit means the build is
+broken or the app never became ready — fix that before driving features.
+
+## Drive
+
+- **Harness:** Playwright's `_electron` driving the built app. Prefer stable
+  handles over coordinates: sidebar items are buttons with accessible names
+  `New session`, `Search`, `Projects`, `Activity`, `Scheduled`, `Capabilities`;
+  each page asserts its level-1 heading; Settings opens from the
+  `.sidebar__footer` `Settings` button and lands on the `General` heading, with
+  sections as buttons named `Appearance`, `Pets`, `Harness`, etc.
+- **Scenarios:** `node .cursor/skills/verify-gooeypi/control.mjs list` →
+  `navigation`, `settings`, `capabilities`. Each is one self-contained
+  launch → drive → capture → teardown. The [feature map](./features/README.md)
+  documents these plus features (session messaging) that need the repo's
+  hermetic fixture rather than this driver.
+
+## Evidence
+
+- Each scenario writes PNG screenshots and `.aria.txt` ARIA snapshots to
+  `--out DIR` (default `/tmp/gooeypi-verify/<scenario>-<timestamp>`) and prints a
+  `PROVEN:` list of the assertions it checked.
+- **Proof standard:** drive the real user path and capture both the action and
+  the resulting page state (heading + ARIA), not just a final screen. For a
+  mutation (creating a schedule or sending a message), also verify the side
+  effect — a file written under the harness `HOME`, or a second read-only view —
+  not just a toast. Record the feature ID and the entry point used.
+- Artifacts survive teardown. Copy any you want to keep into
+  `/opt/cursor/artifacts` for a PR walkthrough.
+
+## Cleanup
+
+- The driver closes only the app instance it launched and removes only the
+  throwaway fixture `HOME`/`user-data-dir` it created. It never deletes evidence
+  dirs. **Never** kill Electron by name (`pkill electron`); the driver owns its
+  own child process and tears it down.
+
+## Helpers
+
+- [`control.mjs`](./control.mjs) (executable). Subcommands: `doctor`,
+  `drive <scenario>`, `list`. Invoke exactly as shown above; run under
+  `xvfb-run` on headless machines.

--- a/.cursor/skills/verify-gooeypi/control.mjs
+++ b/.cursor/skills/verify-gooeypi/control.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// GooeyPi verification driver.
+//
+// Launches the BUILT GooeyPi Electron app in an isolated, disposable HOME +
+// Electron user-data-dir, drives one user-facing scenario the way a person
+// would (sidebar clicks, keyboard shortcuts), and captures evidence
+// (screenshot + ARIA snapshot). Each invocation is a self-contained session:
+// launch -> drive -> capture -> tear down. It never touches your real
+// ~/.prime / ~/.omp / ~/.pi state or an app instance it did not start.
+//
+// Requires a display. On a headless machine wrap the command in `xvfb-run -a`.
+//
+// Usage:
+//   node control.mjs doctor [--out DIR]
+//   node control.mjs drive <navigation|settings|capabilities> [--out DIR]
+//   node control.mjs list
+//
+// Exit code 0 = healthy / scenario proved; non-zero = failure (details on stderr).
+
+import { _electron as electron } from '@playwright/test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(HERE, '../../..')
+const READY = '.app-shell[data-ready="true"]'
+const READY_TIMEOUT = 30_000
+
+function parseArgs(argv) {
+  const out = { _: [] }
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--out') { out.out = argv[i + 1]; i += 1 }
+    else out._.push(argv[i])
+  }
+  return out
+}
+
+function log(msg) { process.stdout.write(`[verify-gooeypi] ${msg}\n`) }
+
+function makeOutDir(explicit, name) {
+  const base = explicit
+    ? resolve(explicit)
+    : join(tmpdir(), 'gooeypi-verify', `${name}-${new Date().toISOString().replace(/[:.]/g, '-')}`)
+  mkdirSync(base, { recursive: true })
+  return base
+}
+
+async function launch() {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'gooeypi-verify-fixture-'))
+  const home = join(fixtureRoot, 'home')
+  const userData = join(fixtureRoot, 'user-data')
+  mkdirSync(home, { recursive: true })
+  mkdirSync(userData, { recursive: true })
+
+  const env = { ...process.env, HOME: home, PRIME_WORK_E2E_HIDE_WINDOWS: '0' }
+  if (!env.DISPLAY) throw new Error('No DISPLAY set. Run under `xvfb-run -a` or an X server.')
+
+  const app = await electron.launch({
+    args: ['.', `--user-data-dir=${userData}`],
+    cwd: REPO_ROOT,
+    env,
+    timeout: 30_000,
+  })
+  const page = await app.firstWindow({ timeout: 20_000 })
+  const errors = []
+  page.on('pageerror', (e) => errors.push(e.message))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()) })
+  await page.waitForSelector(READY, { timeout: READY_TIMEOUT })
+  await dismissNoHarnessPrompt(page)
+  return { app, page, fixtureRoot, errors }
+}
+
+// A fresh HOME has no Pi/OMP/Prime harness, so GooeyPi shows a modal that makes
+// the shell `inert`. Dismiss it so the sidebar is interactive. This is expected
+// verification-only state, not a defect.
+async function dismissNoHarnessPrompt(page) {
+  const dialog = page.getByRole('dialog', { name: 'No Pi family harness detected' })
+  if (await dialog.isVisible().catch(() => false)) {
+    await dialog.getByRole('button', { name: 'Close' }).click()
+    await dialog.waitFor({ state: 'hidden', timeout: 8_000 })
+    log('dismissed "No Pi family harness detected" prompt (empty verification HOME)')
+  }
+}
+
+async function teardown(session) {
+  try { await session.app.close() } catch { /* already gone */ }
+  if (session.fixtureRoot) rmSync(session.fixtureRoot, { recursive: true, force: true })
+}
+
+async function capture(page, outDir, name) {
+  const png = join(outDir, `${name}.png`)
+  const aria = join(outDir, `${name}.aria.txt`)
+  await page.screenshot({ path: png })
+  try { writeFileSync(aria, await page.locator('.app-shell').ariaSnapshot()) } catch { /* best effort */ }
+  log(`captured ${name}: ${png}`)
+}
+
+// --- Scenarios ---------------------------------------------------------------
+// Each returns a list of proven assertions (strings) or throws on failure.
+
+async function doctor(page, outDir) {
+  const proofs = []
+  const title = await page.title()
+  proofs.push(`window title: ${JSON.stringify(title)}`)
+  const ready = await page.locator('.app-shell').getAttribute('data-ready')
+  if (ready !== 'true') throw new Error(`app-shell data-ready=${ready}, expected true`)
+  proofs.push('app-shell data-ready=true')
+  await capture(page, outDir, 'doctor')
+  return proofs
+}
+
+async function navigation(page, outDir) {
+  const proofs = []
+  // Each sidebar button opens a page whose level-1 heading proves the route.
+  // Capabilities titles as "Extend <active harness>" (harness-dependent).
+  const pages = [
+    { button: 'Projects', heading: 'Projects' },
+    { button: 'Activity', heading: 'Activity' },
+    { button: 'Scheduled', heading: 'Scheduled' },
+    { button: 'Capabilities', heading: /^Extend / },
+  ]
+  for (const p of pages) {
+    await page.getByRole('button', { name: p.button, exact: true }).click()
+    await page.getByRole('heading', { name: p.heading, level: 1 }).first().waitFor({ state: 'visible', timeout: 8_000 })
+    await capture(page, outDir, `nav-${p.button.toLowerCase()}`)
+    proofs.push(`${p.button} -> level-1 heading ${p.heading} visible`)
+  }
+  return proofs
+}
+
+async function settings(page, outDir) {
+  const proofs = []
+  await page.locator('.sidebar__footer button').filter({ hasText: 'Settings' }).click()
+  await page.getByRole('heading', { name: 'General' }).waitFor({ state: 'visible', timeout: 8_000 })
+  await capture(page, outDir, 'settings-general')
+  proofs.push('Settings opened -> "General" heading visible')
+
+  for (const section of ['Appearance', 'Pets']) {
+    await page.getByRole('button', { name: section, exact: true }).click()
+    await page.getByRole('heading', { name: section, exact: true }).first().waitFor({ state: 'visible', timeout: 8_000 })
+    await capture(page, outDir, `settings-${section.toLowerCase()}`)
+    proofs.push(`Settings section "${section}" -> heading visible`)
+  }
+
+  await page.keyboard.press('Escape')
+  await page.locator(READY).waitFor({ state: 'visible', timeout: 8_000 })
+  proofs.push('Escape closed Settings -> returned to app shell')
+  return proofs
+}
+
+async function capabilities(page, outDir) {
+  const proofs = []
+  await page.getByRole('button', { name: 'Capabilities', exact: true }).click()
+  await page.getByRole('heading', { name: /^Extend /, level: 1 }).first().waitFor({ state: 'visible', timeout: 8_000 })
+  // The page exposes Capabilities/Skills tabs and a directory heading.
+  await page.getByRole('heading', { name: 'Capabilities', level: 2 }).first().waitFor({ state: 'visible', timeout: 8_000 })
+  await capture(page, outDir, 'capabilities')
+  proofs.push('Capabilities page shows "Extend <harness>" h1 and a Capabilities directory heading')
+  return proofs
+}
+
+const SCENARIOS = { navigation, settings, capabilities }
+
+// --- Entry -------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const command = args._[0]
+
+  if (command === 'list') {
+    log(`scenarios: ${Object.keys(SCENARIOS).join(', ')}`)
+    return
+  }
+
+  if (command !== 'doctor' && command !== 'drive') {
+    process.stderr.write('Usage: node control.mjs <doctor|drive <scenario>|list> [--out DIR]\n')
+    process.exit(2)
+  }
+
+  const scenarioName = command === 'doctor' ? 'doctor' : args._[1]
+  if (command === 'drive' && !SCENARIOS[scenarioName]) {
+    process.stderr.write(`Unknown scenario "${scenarioName}". Known: ${Object.keys(SCENARIOS).join(', ')}\n`)
+    process.exit(2)
+  }
+
+  const outDir = makeOutDir(args.out, scenarioName)
+  log(`repo: ${REPO_ROOT}`)
+  log(`evidence dir: ${outDir}`)
+  let session
+  try {
+    log('launching built app (needs out/main/index.js; run `npm run build` if missing)...')
+    session = await launch()
+    log('app ready (.app-shell[data-ready=true])')
+    const runner = command === 'doctor' ? doctor : SCENARIOS[scenarioName]
+    const proofs = await runner(session.page, outDir)
+    if (session.errors.length) log(`renderer errors observed (non-fatal): ${session.errors.length}`)
+    log('PROVEN:')
+    for (const p of proofs) log(`  - ${p}`)
+    log(`OK: ${scenarioName}. Evidence in ${outDir}`)
+  } catch (error) {
+    process.stderr.write(`[verify-gooeypi] FAILED: ${scenarioName}: ${error?.message ?? error}\n`)
+    if (session) { try { await capture(session.page, outDir, `${scenarioName}-failure`) } catch { /* ignore */ } }
+    await teardown(session)
+    process.exit(1)
+  }
+  await teardown(session)
+}
+
+main()

--- a/.cursor/skills/verify-gooeypi/features/README.md
+++ b/.cursor/skills/verify-gooeypi/features/README.md
@@ -1,0 +1,60 @@
+# GooeyPi verification map
+
+This directory is the maintained source for verifying the user-facing behavior
+of GooeyPi (a desktop Electron app). Read this index before driving the app,
+then use the matching feature file as the recipe. Keep it honest as the app
+changes — a proof that drives one convenient entry point is incomplete when the
+map lists others.
+
+## Baseline preconditions
+
+- The app is built (`out/main/index.js` exists); if not, run `npm run build`.
+- `node -v` is `v24.15.0` (load nvm first if not: `. "$HOME/.nvm/nvm.sh"; nvm use`).
+- A display is available; on a headless machine prefix commands with `xvfb-run -a`.
+- Drives run against a throwaway `HOME` + Electron `--user-data-dir`, so the real
+  `~/.prime` / `~/.omp` / `~/.pi` state is never touched.
+- The driver dismisses the `No Pi family harness detected` modal automatically
+  (a fresh `HOME` has no harness).
+- Never drive an app instance this verification run did not start.
+
+## Driving conventions
+
+- Start every recipe from a fresh launch unless its preconditions say otherwise.
+- Prefer roles and accessible names over CSS selectors or DOM position.
+- Treat every command as literal. Keep quoted names and flags unchanged.
+- Run scenarios through `node .cursor/skills/verify-gooeypi/control.mjs`.
+- The driver removes the fixture it created and keeps every evidence artifact.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting page state (heading + ARIA), not
+  only the final screen.
+- UI proof includes a screenshot with the app identity visible and the `PROVEN:`
+  assertion list from stdout.
+- Mutation proof includes a second read-only view of the stored value (a file
+  under the harness `HOME`, or the item re-read from the list).
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet
+  precondition. Do not report a skipped entry point as verified through another.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the
+user-visible behavior, then uses exactly four H2 sections in this order:
+
+1. `Sub-features` — short IDs with one line each.
+2. `How to get to it (user POV)` — every user entry point.
+3. `Driving it with gooeypi-control` — starts with `Preconditions:` and pairs
+   each user action with an exact command and observable result.
+4. `Gotchas` — traps that can waste or invalidate a verification run.
+
+## Features
+
+- [Sidebar navigation](./navigation.md) — moving between Projects, Activity,
+  Scheduled, and Capabilities and proving each route by its heading.
+- [Settings](./settings.md) — opening Settings, switching sections, and closing.
+- [Capabilities](./capabilities.md) — the capabilities/skills directory for the
+  active harness.
+- [Sessions and messaging](./sessions-and-messaging.md) — selecting a session
+  and sending/queueing a prompt. Needs the repo's hermetic fixture (fake harness
+  binaries); not drivable by `control.mjs` alone.

--- a/.cursor/skills/verify-gooeypi/features/capabilities.md
+++ b/.cursor/skills/verify-gooeypi/features/capabilities.md
@@ -1,0 +1,42 @@
+# Capabilities
+
+The Capabilities page is the directory of packages, plugins, extensions, MCP
+servers, and reusable skills for the active harness. It titles as
+`Extend <harness>` and exposes `Capabilities` and `Skills` tabs with a filtered
+directory list.
+
+## Sub-features
+
+- `cap-open` opens the capabilities directory for the active harness.
+- `cap-tabs` switches between the `Capabilities` and `Skills` tabs.
+- `cap-directory` shows the directory heading with a shown-count.
+
+## How to get to it (user POV)
+
+- Click `Capabilities` in the sidebar.
+- Within the page, switch the `Capabilities` / `Skills` tab buttons.
+
+## Driving it with gooeypi-control
+
+Preconditions:
+
+- Doctor is green.
+
+- **Open the directory.** Run
+  `xvfb-run -a node .cursor/skills/verify-gooeypi/control.mjs drive capabilities --out /tmp/gooeypi-verify/capabilities`.
+  Expected `PROVEN:` line: `Capabilities page shows "Extend <harness>" h1 and a
+  Capabilities directory heading`.
+- **Proof.** The run writes `capabilities.png` (plus `.aria.txt`) showing the
+  `Extend <harness>` title, the Capabilities/Skills tabs, and the directory
+  heading with a `N shown` count.
+
+## Gotchas
+
+- The word `Capabilities` appears three ways: the sidebar button, the in-page tab
+  button, and the level-2 directory heading. Matching `Capabilities` by role
+  `button` hits both the sidebar and the tab (strict-mode failure); assert the
+  level-1 `^Extend ` heading and the level-2 `Capabilities` directory heading.
+- The exact harness word in `Extend <harness>` depends on the active harness
+  (Pi/OMP/Prime), which the switcher in the top-left controls; do not hard-code it.
+- Network MCP capabilities render but are read-only in GooeyPi; a row appearing
+  is not proof it was installed by this run.

--- a/.cursor/skills/verify-gooeypi/features/navigation.md
+++ b/.cursor/skills/verify-gooeypi/features/navigation.md
@@ -1,0 +1,45 @@
+# Sidebar navigation
+
+The left sidebar switches the main pane between the workspace and the Projects,
+Activity, Scheduled, and Capabilities pages. Each destination proves itself by
+its level-1 heading, so navigation is verifiable without any harness installed.
+
+## Sub-features
+
+- `nav-projects` opens the Projects library (`Projects` heading).
+- `nav-activity` opens the Activity view (`Activity` heading).
+- `nav-scheduled` opens the Automation Desk (`Scheduled` heading).
+- `nav-capabilities` opens the capabilities directory (`Extend <harness>` heading).
+
+## How to get to it (user POV)
+
+- Click a sidebar item: `Projects`, `Activity`, `Scheduled`, or `Capabilities`.
+- `New session` and `Search` at the top return to / focus the workspace.
+
+## Driving it with gooeypi-control
+
+Preconditions:
+
+- Doctor is green: `xvfb-run -a node .cursor/skills/verify-gooeypi/control.mjs doctor` exits 0 and prints window title `GooeyPi`.
+- The build exists (`out/main/index.js`).
+
+- **Visit every page.** Click each sidebar button in turn and confirm its
+  heading. Run `xvfb-run -a node .cursor/skills/verify-gooeypi/control.mjs drive navigation --out /tmp/gooeypi-verify/navigation`.
+  Expected `PROVEN:` lines: `Projects -> level-1 heading Projects`,
+  `Activity -> level-1 heading Activity`, `Scheduled -> level-1 heading Scheduled`,
+  `Capabilities -> level-1 heading /^Extend /`.
+- **Proof.** The run writes `nav-projects.png`, `nav-activity.png`,
+  `nav-scheduled.png`, and `nav-capabilities.png` (plus `.aria.txt` snapshots) to
+  the `--out` dir. The Scheduled shot shows the `AUTOMATION DESK` kicker and
+  `No active schedules`; the Capabilities shot shows the Capabilities/Skills tabs.
+
+## Gotchas
+
+- On a fresh `HOME` the `No Pi family harness detected` modal makes the shell
+  `inert`; the driver dismisses it first. If you drive manually, close that modal
+  (its `Close` button) before clicking the sidebar or every click times out.
+- The Capabilities heading is `Extend <active harness>` (e.g. `Extend OMP`), not
+  the literal word "Capabilities"; assert the `^Extend ` heading or the level-2
+  `Capabilities` directory heading, not the sidebar button text.
+- `Scheduled` and `Capabilities` also appear as words elsewhere (kicker, tabs);
+  match on the level-1 heading to avoid strict-mode ambiguity.

--- a/.cursor/skills/verify-gooeypi/features/sessions-and-messaging.md
+++ b/.cursor/skills/verify-gooeypi/features/sessions-and-messaging.md
@@ -1,0 +1,49 @@
+# Sessions and messaging
+
+A user selects a persistent session and sends a prompt to the active harness;
+while a turn runs they can queue a follow-up or steer the turn. This is the core
+product loop, but it requires a working Pi/OMP/Prime harness — so it is driven by
+the repo's hermetic Playwright fixture (which installs fake harness binaries),
+**not** by `control.mjs`, whose disposable `HOME` has no harness.
+
+## Sub-features
+
+- `msg-select` selects a session from the sidebar list.
+- `msg-send` sends a prompt via the composer and starts a turn.
+- `msg-queue` queues a follow-up while a turn is running.
+- `msg-steer` steers the running turn with `Ctrl+Enter`.
+
+## How to get to it (user POV)
+
+- Click a session row in the sidebar, then type in the composer (`Message Prime`
+  / `Message OMP`) and press `Enter` to send.
+- While the `Stop Prime` button is visible (turn running), press `Enter` to queue
+  or `Ctrl+Enter` to steer.
+
+## Driving it with gooeypi-control
+
+Preconditions:
+
+- A Pi-family harness is available. `control.mjs` cannot supply one, so this
+  feature is **skipped by the standalone driver** and verified through the repo
+  fixture instead.
+
+- **Run the fixture path.** Use the repo's hermetic Electron suite, which sets
+  `PRIME_AGENT_BINARY` / `OMP_BINARY` / `PI_BINARY` to fake executables and drives
+  the composer. Run `xvfb-run -a npx playwright test tests/e2e/app.spec.ts -g "steers the active turn with Ctrl\\+Enter" --reporter=line`.
+- **Observable proof.** The fake harness writes `steer-args.json` under the
+  fixture root; the test asserts `{ type: 'steer', message: 'change direction now' }`,
+  i.e. the mutation (the steer reaching the harness), not just on-screen text.
+- To drive this manually with `control.mjs`, you would first need real or fake
+  harness binaries on `PATH` inside the driver's `HOME`; until the driver grows
+  a `--harness` fixture mode, prefer the Playwright path above.
+
+## Gotchas
+
+- With no harness, GooeyPi shows `No Pi family harness detected` and the composer
+  is disabled — messaging cannot be proven; report it skipped with this reason,
+  do not substitute the navigation scenario as evidence.
+- A queued/steered message is only proven by its side effect (the marker file the
+  harness receives), not by the composer clearing or a message bubble appearing.
+- The composer accessible name is harness-specific (`Message Prime` vs
+  `Message OMP`); match the active harness shown in the top-left switcher.

--- a/.cursor/skills/verify-gooeypi/features/settings.md
+++ b/.cursor/skills/verify-gooeypi/features/settings.md
@@ -1,0 +1,45 @@
+# Settings
+
+Settings opens over the workspace as a sectioned page (General, Appearance,
+Harness, Providers, Voice, Pets, Browser, Terminal, Privacy, About). A user
+opens it, switches sections, and closes it back to the workspace.
+
+## Sub-features
+
+- `settings-open` opens Settings on the `General` section.
+- `settings-section` switches to another section by its sidebar button.
+- `settings-close` closes Settings and returns to the app shell.
+
+## How to get to it (user POV)
+
+- Click the `Settings` button in the sidebar footer.
+- The keyboard shortcut `Ctrl+,` (macOS `⌘+,`) also opens Settings.
+- Section switches are the buttons named `General`, `Appearance`, `Harness`,
+  `Providers`, `Voice`, `Pets`, etc.
+
+## Driving it with gooeypi-control
+
+Preconditions:
+
+- Doctor is green.
+
+- **Open and tour sections.** Open Settings, then visit Appearance and Pets. Run
+  `xvfb-run -a node .cursor/skills/verify-gooeypi/control.mjs drive settings --out /tmp/gooeypi-verify/settings`.
+  Expected `PROVEN:` lines: `Settings opened -> "General" heading visible`,
+  `Settings section "Appearance" -> heading visible`,
+  `Settings section "Pets" -> heading visible`,
+  `Escape closed Settings -> returned to app shell`.
+- **Proof.** The run writes `settings-general.png`, `settings-appearance.png`,
+  and `settings-pets.png` (plus `.aria.txt`) to the `--out` dir. Appearance shows
+  the System/Light/Dark theme control; Pets shows the active companion and size
+  slider.
+
+## Gotchas
+
+- The Settings section headings collide with other page text; assert the heading
+  role (e.g. `heading` name `Pets` exact) rather than any occurrence of the word.
+- `Escape` closes Settings via its focus trap. If a section has focus inside a
+  text field, `Escape` still closes the page here, but verify the app shell is
+  visible again (`.app-shell[data-ready="true"]`) rather than assuming.
+- Opening Settings from a fresh `HOME` still works; the `Harness` section will
+  report no detected harness, which is expected verification state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,35 @@ When changing an existing production file above the threshold, avoid increasing 
 
 This threshold does not apply to tests, generated files, vendored code, lockfiles, fixtures, or data assets. Correctness, security boundaries, and maintainable ownership take precedence over line count.
 
+## Cloud Agent environment
+
+Cloud Agents provision this repo with [`.cursor/environment.json`](.cursor/environment.json),
+whose `install` step runs [`.cursor/install.sh`](.cursor/install.sh) on Cursor's
+default Ubuntu image. That script pins Node via `.nvmrc` (24.15.0) with `nvm`,
+installs the Electron/xvfb system libraries, bootstraps the repo-pinned npm, and
+runs `npm ci`. Canonical toolchain and check commands live in
+[`docs/validation.md`](docs/validation.md); do not restate versions here.
+
+`node`/`npm` come from `nvm`. A fresh login shell already selects 24.15.0; in a
+non-login shell load it first:
+
+```
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use >/dev/null
+```
+
+GooeyPi is a GUI Electron app with no background services, so there is nothing to
+auto-start. To run the app or the Playwright Electron e2e suite headlessly, wrap
+the command with a virtual display:
+
+```
+xvfb-run -a npm run dev              # launch the desktop app
+xvfb-run -a npm run test:e2e:hermetic # build + hermetic Electron e2e
+```
+
+Some xterm/PTY-driven e2e cases in `tests/e2e/app.spec.ts` are timing-sensitive
+under headless `xvfb` and can fail where they pass on the macOS CI runner that
+owns the `hermetic-e2e` gate.
+
 ## pstack
 
 This repository vendors [pstack](https://github.com/cursor/plugins/tree/main/pstack) under `.agents/skills/pstack/` so Cloud Agents can run `/poteto-mode` and the rest of the skill set. Subagents live in `.cursor/agents/`. Per-role model overrides live in `.cursor/rules/pstack-models.mdc`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,9 @@ installs the Electron/xvfb system libraries, bootstraps the repo-pinned npm, and
 runs `npm ci`. Canonical toolchain and check commands live in
 [`docs/validation.md`](docs/validation.md); do not restate versions here.
 
-`node`/`npm` come from `nvm`. A fresh login shell already selects 24.15.0; in a
-non-login shell load it first:
+`node`/`npm` come from `nvm`. A harness shell can be shadowed by another `node`
+on `PATH`, so select the pinned toolchain before running `node`/`npm` if `node
+-v` is not `v24.15.0`:
 
 ```
 export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use >/dev/null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two related deliverables for GooeyPi:

1. A **repository-managed Cloud Agent development environment** so agents can install, lint, type-check, test, build, and run the Electron desktop app end to end.
2. A **project-local verification skill** (`verify-gooeypi`) that launches the built app and drives real user-facing flows to prove behavior with captured evidence.

## 1. Cloud Agent environment

The repo previously had no environment configuration. This adds:

- **`.cursor/environment.json`** — repository-managed config on Cursor's default Ubuntu image, running the install script as `ubuntu`.
- **`.cursor/install.sh`** — an idempotent bootstrap that pins Node `24.15.0` from `.nvmrc` via `nvm`, installs the repo-pinned npm `12.0.2`, installs the Electron + `xvfb` system libraries, and runs `npm ci` (rebuilds `node-pty`, downloads the Electron runtime; `zeromq`/`koffi` ship vendored prebuilts, so npm 12's default script-blocking is fine).
- **`AGENTS.md`** — durable guidance: selecting the `nvm` toolchain and running the GUI/e2e headlessly via `xvfb-run`.

GooeyPi is a GUI Electron app with no background services, so the config is `install`-only.

### Validation (on the tested VM)

| Check | Result |
|---|---|
| Toolchain preflight | Node v24.15.0, npm 12.0.2 |
| `npm run typecheck` | Passed |
| `npm run check` (biome lint + format) | Passed — 389 files |
| `npm run test` (vitest) | 1828 passed / 1 skipped; a few fs-watch/timing tests flake only under full parallel load and pass in isolation |
| `npm run build` | Passed |
| `npm run test:e2e:hermetic` (xvfb) | 55 passed / 3 skipped; 6 xterm/PTY interaction tests fail under headless `xvfb` (this gate targets the macOS CI runner) |
| `.cursor/install.sh` idempotence | Passed twice (~16s, ~14s) |
| Draft build `bld-20260827-baf5cb11-…` | SUCCEEDED — install ran from a clean checkout on the default image |
| Fresh Cloud Agent booted from that build | Node/npm correct, deps baked in, typecheck + build green, GUI renders headlessly, Electron launches under Playwright |

## 2. `verify-gooeypi` verification skill

`.cursor/skills/verify-gooeypi/` — a scripted way to drive the real GooeyPi desktop app and prove user-facing behavior:

- **`control.mjs`** — a standalone Playwright `_electron` driver (`doctor`, `drive <scenario>`, `list`). Each drive launches the built app in a disposable `HOME` + Electron `--user-data-dir` (never touching real `~/.prime`/`~/.omp`/`~/.pi`), dismisses the fresh-profile "No Pi family harness detected" modal, drives a flow by role/accessible-name, captures screenshots + ARIA snapshots, and tears down only what it started.
- **`SKILL.md`** — Launch / Doctor / Drive / Evidence / Cleanup / Helpers, grounded in the repo's actual selectors and toolchain.
- **`features/`** — the maintained feature map: `navigation`, `settings`, `capabilities`, and `sessions-and-messaging` (which honestly defers to the repo's hermetic Playwright fixture because messaging needs a real/fake harness).

### Skill proven end to end

- `doctor` → window title `GooeyPi`, `.app-shell[data-ready="true"]`.
- `drive navigation` → Projects / Activity / Scheduled / Capabilities each proved by their level-1 heading, with a screenshot per page.
- `drive settings` and `drive capabilities` → pass with captured evidence.
- Evidence persists after cleanup; **0** leaked fixture dirs and **0** stray Electron processes.
- The `sessions-and-messaging` fixture recipe was validated (`1 passed`).

Capabilities and Scheduled pages captured by the driver:

[GooeyPi Capabilities page driven by verify-gooeypi](https://cursor.com/agents/bc-f52c59ed-3f9f-4892-8d4d-73131ae260a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify-gooeypi-capabilities.png)
[GooeyPi Scheduled page driven by verify-gooeypi](https://cursor.com/agents/bc-f52c59ed-3f9f-4892-8d4d-73131ae260a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify-gooeypi-scheduled.png)

## Walkthrough (environment: live app interaction)

[gooeypi-app-walkthrough.mp4](https://cursor.com/agents/bc-f52c59ed-3f9f-4892-8d4d-73131ae260a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgooeypi-app-walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f52c59ed-3f9f-4892-8d4d-73131ae260a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f52c59ed-3f9f-4892-8d4d-73131ae260a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

