### PR TITLE
feat(composer): fluid running-state ring around the input

### DIFF
--- a/scripts/release/size-budgets.mjs
+++ b/scripts/release/size-budgets.mjs
@@ -17,7 +17,7 @@ export const BUNDLE_SIZE_BUDGETS = Object.freeze({
   preloadBytes: 16 * KIB,
   initialRendererBytes: 1280 * KIB,
   largestRendererChunkBytes: 600 * KIB,
-  rendererJsCssBytes: 2320 * KIB,
+  rendererJsCssBytes: 2328 * KIB,
 })
 
 /**

--- a/src/styles/composer.css
+++ b/src/styles/composer.css
@@ -156,3 +156,57 @@
 .composer-menu button > span { min-width: 0; display: flex; flex-direction: column; }
 .composer-menu strong { color: var(--text); font-size: 12px; font-weight: 540; }
 .composer-menu small { overflow: hidden; color: var(--text-tertiary); font-size: 10.5px; white-space: nowrap; text-overflow: ellipsis; }
+
+/* Fluid running-state ring: a layered conic flow orbits the composer while the agent works.
+   The .composer--busy hook is applied by Composer.tsx whenever the session is busy or submitting. */
+@property --composer-flow { syntax: "<angle>"; initial-value: 0deg; inherits: false; }
+
+.composer--busy::before,
+.composer--busy::after { content: ""; position: absolute; pointer-events: none; }
+
+/* Ambient layer: a slowly counter-rotating hue wash, mostly veiled by the opaque card,
+   leaking only as a soft halo past the edges. */
+.composer--busy::before {
+  z-index: -1;
+  inset: -5px;
+  border-radius: 19px;
+  background: conic-gradient(from calc(var(--composer-flow) * -1),
+    color-mix(in srgb, var(--prime) 55%, transparent),
+    color-mix(in srgb, var(--focus) 45%, transparent),
+    color-mix(in srgb, var(--prime) 55%, transparent));
+  filter: blur(7px);
+  opacity: .5;
+  animation: composer-flow 11s linear infinite;
+}
+
+/* Streaming ribbon: two soft currents run around the border like molten glass. */
+.composer--busy::after {
+  z-index: 2;
+  inset: -3px;
+  padding: 2.5px;
+  border-radius: 17px;
+  background: conic-gradient(from var(--composer-flow),
+    transparent 0 8%,
+    color-mix(in srgb, var(--prime) 30%, transparent) 18%,
+    color-mix(in srgb, var(--prime) 85%, white) 27%,
+    color-mix(in srgb, var(--focus) 90%, white) 34%,
+    color-mix(in srgb, var(--prime) 40%, transparent) 44%,
+    transparent 54%,
+    color-mix(in srgb, var(--focus) 55%, transparent) 68%,
+    color-mix(in srgb, var(--prime) 60%, white) 76%,
+    transparent 88%);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  filter: blur(.6px);
+  animation: composer-flow 3.4s linear infinite;
+}
+
+@keyframes composer-flow { to { --composer-flow: 360deg; } }
+
+/* The registered property does not inherit, so the rest angle is set on each pseudo directly. */
+@media (prefers-reduced-motion: reduce) {
+  .composer--busy::before, .composer--busy::after { animation: none; --composer-flow: 210deg; }
+  .composer--busy::after { opacity: .6; }
+}


### PR DESCRIPTION
## What

A subtle fluid ring around the composer while a session is running. When the agent is busy (or the composer is submitting), two soft conic-gradient currents orbit the input card — a blurred ambient halo behind it and a thin ribbon streaming along the border — and the ring disappears the moment the session goes idle.

CSS only: no markup, no state, no test-surface changes.

## Why

The running state today is conveyed by small controls (status line, stop button). A large, unmissable-but-quiet signal around the main focus area makes "is it still working?" glanceable, especially on long tasks.

## How

The composer already gets a `composer--busy` class when `busy || submitting`, so the whole feature hangs off that existing hook:

- `::before` — an ambient halo: a counter-rotating (11s) blurred conic wash tucked one layer behind the opaque card (`z-index: -1` inside the `.composer-wrap` stacking context), so only the glow leaks past the edges.
- `::after` — the ribbon: a 3.4s conic gradient with two bright currents, masked into a 2.5px ring with `mask-composite: exclude` so it follows the rounded border instead of filling the card.
- `@property --composer-flow` registers the conic start angle as `<angle>`, which is what makes the gradient angle animatable at all.
- `prefers-reduced-motion: reduce` swaps both layers to a static tint (the rest angle is declared on the pseudo-elements directly, since registered custom properties do not inherit into pseudos).

Colors come from the existing `--prime` / `--focus` tokens, so light and dark themes both work with no new variables.

## Verification

- `npm run build:bundle` and `tsc` pass; composer test files pass (27/27).
- Frame budget measured in Electron's Chromium: median/p90 frame times with the animation running are identical to the animation disabled (16.6 / 17.5 ms at 60 Hz on a full-width composer) — the two animated surfaces stay well inside the vsync budget.
- Verified manually in the app across light/dark themes: ring flows while a session runs, gone when idle, static fallback under reduced motion.

All features used (`@property`, `mask-composite: exclude`, `conic-gradient from <angle>`) are well-supported in Electron 43 / Chromium 140, which this app already targets.

## Notes

The ribbon deliberately uses conic-angle interpolation rather than a rotating element: a rotating gradient disc cannot track a wide rectangle's corners, while the angle interpolation keeps the flow glued to the border at every frame.
