### PR TITLE
fix(browser): cancel guest calls stranded by navigation

### DIFF
--- a/electron/main/browser/agent-service.ts
+++ b/electron/main/browser/agent-service.ts
@@ -24,6 +24,18 @@ const MAX_TABS_PER_SESSION = 6
 const MAX_TABS_TOTAL = 24
 const ATTACH_TIMEOUT_MS = 15_000
 const LOAD_TIMEOUT_MS = 20_000
+/**
+ * Ceiling for a single guest call (script, input, capture). Electron never
+ * settles `executeJavaScript` when a navigation destroys the execution context
+ * that owns its promise, so every guest await needs its own deadline.
+ */
+const ACTION_TIMEOUT_MS = 30_000
+/**
+ * Extra margin before the per-tab queue releases a still-pending action. Each
+ * guest call already carries ACTION_TIMEOUT_MS, so reaching this means the
+ * action is pathologically stuck and liveness matters more than serialization.
+ */
+const QUEUE_RELEASE_GRACE_MS = 5_000
 const SETTLE_MS = 150
 const MAX_TYPE_CHARS = 8_000
 const MAX_EVALUATE_CHARS = 16_000
@@ -33,6 +45,13 @@ const MAX_READ_ELEMENTS = 300
 const MAX_SCREENSHOT_BYTES = 4 * 1024 * 1024
 const SCREENSHOT_JPEG_QUALITY = 70
 const ACTION_REVOKED_MESSAGE = 'Browser tab access changed before this action could start'
+/**
+ * A navigation replaced the document while a guest call was in flight. Chromium
+ * discards the old execution context together with any promise it owns, so the
+ * call can never settle and has to be reported instead of awaited forever.
+ */
+const NAVIGATION_ABORTED_MESSAGE = 'The page navigated while this action was running, so it was cancelled. Navigate with browser_navigate first, then run the action.'
+const ACTION_TIMED_OUT_MESSAGE = 'The page did not answer this action in time and it was cancelled.'
 
 interface CdpKey {
   key: string
@@ -101,6 +120,8 @@ export interface AgentBrowserServiceOptions {
   getGuest(webContentsId: number): WebContents | undefined
   attachTimeoutMs?: number
   loadTimeoutMs?: number
+  /** Deadline for a single guest call; also bounds the per-tab queue release. */
+  actionTimeoutMs?: number
 }
 
 function isAllowedTabUrl(raw: string): boolean {
@@ -144,11 +165,13 @@ export class AgentBrowserService {
   private readonly activityListeners = new Set<(event: AgentBrowserActivityEvent) => void>()
   private readonly attachTimeoutMs: number
   private readonly loadTimeoutMs: number
+  private readonly actionTimeoutMs: number
   private closed = false
 
   constructor(private readonly options: AgentBrowserServiceOptions) {
     this.attachTimeoutMs = options.attachTimeoutMs ?? ATTACH_TIMEOUT_MS
     this.loadTimeoutMs = options.loadTimeoutMs ?? LOAD_TIMEOUT_MS
+    this.actionTimeoutMs = options.actionTimeoutMs ?? ACTION_TIMEOUT_MS
   }
 
   // ---- lifecycle -----------------------------------------------------------
@@ -450,12 +473,12 @@ export class AgentBrowserService {
     return this.withTab(sessionKey, params, async (tab, guest) => {
       const info = await this.pageInfo(guest)
       // Show the agent its own pointer in the capture so it can calibrate.
-      if (tab.pointer) await guest.executeJavaScript(cursorMarkerScript(tab.pointer.x, tab.pointer.y)).catch(() => undefined)
+      if (tab.pointer) await this.guardGuestCall(guest, guest.executeJavaScript(cursorMarkerScript(tab.pointer.x, tab.pointer.y))).catch(() => undefined)
       let image: Electron.NativeImage
       try {
-        image = await guest.capturePage(undefined, { stayHidden: true, stayAwake: true })
+        image = await this.guardGuestCall(guest, guest.capturePage(undefined, { stayHidden: true, stayAwake: true }))
       } finally {
-        if (tab.pointer) void guest.executeJavaScript(removeCursorMarkerScript()).catch(() => undefined)
+        if (tab.pointer) void this.guardGuestCall(guest, guest.executeJavaScript(removeCursorMarkerScript())).catch(() => undefined)
       }
       const size = image.getSize()
       if (!size.width || !size.height) throw new Error('The browser tab has no visible content to capture yet')
@@ -577,7 +600,7 @@ export class AgentBrowserService {
         await delay(SETTLE_MS)
         return this.describe(tab, guest)
       }
-      const payload = parseScriptJson(await guest.executeJavaScript(scrollByScript(deltaX, deltaY)), 'scroll')
+      const payload = await this.runPageScript(guest, scrollByScript(deltaX, deltaY), 'scroll')
       return { ...await this.describe(tab, guest), ...payload }
     })
   }
@@ -586,14 +609,14 @@ export class AgentBrowserService {
     return this.withTab(sessionKey, params, async (_tab, guest) => {
       const mode = params.mode === undefined ? 'interactive' : requireString(params.mode, 'mode', { min: 1, max: 16, trim: true })
       if (mode !== 'interactive' && mode !== 'text') throw new TypeError('mode must be interactive or text')
-      return parseScriptJson(await guest.executeJavaScript(readPageScript(mode, MAX_READ_TEXT_CHARS, MAX_READ_ELEMENTS)), 'read_page')
+      return this.runPageScript(guest, readPageScript(mode, MAX_READ_TEXT_CHARS, MAX_READ_ELEMENTS), 'read_page')
     })
   }
 
   async evaluate(sessionKey: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
     return this.withTab(sessionKey, params, async (_tab, guest) => {
       const code = requireString(params.code, 'code', { min: 1, max: MAX_EVALUATE_CHARS })
-      return parseScriptJson(await guest.executeJavaScript(evaluateScript(code, MAX_EVALUATE_RESULT_CHARS)), 'evaluate')
+      return this.runPageScript(guest, evaluateScript(code, MAX_EVALUATE_RESULT_CHARS), 'evaluate')
     })
   }
 
@@ -654,7 +677,7 @@ export class AgentBrowserService {
       // already using Electron's guest APIs; it may finish or fail naturally.
       return action(tab, guest)
     })
-    tab.serial.tail = run.catch(() => undefined)
+    tab.serial.tail = this.releaseQueueEventually(run)
     return run
   }
 
@@ -663,6 +686,65 @@ export class AgentBrowserService {
     if (this.closed || tab.revoked || tab.generation !== generation || tab.sessionKey !== sessionKey || current !== tab) {
       throw new Error(ACTION_REVOKED_MESSAGE)
     }
+  }
+
+  /**
+   * Bounds one guest call. Chromium destroys the execution context that owns an
+   * `executeJavaScript` promise when the document is replaced, so the promise
+   * neither resolves nor rejects; without this the caller waits forever and the
+   * tab's action queue never drains again. Same-document navigations keep the
+   * context alive and are ignored.
+   */
+  private guardGuestCall<T>(guest: WebContents, call: Promise<T>): Promise<T> {
+    // Reassigned by the executor below before any listener can fire.
+    let cleanup = (): void => {}
+    const interrupted = new Promise<never>((_resolveInterrupt, reject) => {
+      const fail = (message: string) => {
+        cleanup()
+        reject(new Error(message))
+      }
+      const onNavigation = (details: { isSameDocument?: boolean; isMainFrame?: boolean }) => {
+        if (details?.isSameDocument) return
+        if (details?.isMainFrame === false) return
+        fail(NAVIGATION_ABORTED_MESSAGE)
+      }
+      // Guest destruction is deliberately not an interrupt: Electron settles the
+      // pending call itself, and already-running work is never retroactively
+      // cancelled. Only a context-replacing navigation strands the promise.
+      const timer = setTimeout(() => fail(ACTION_TIMED_OUT_MESSAGE), this.actionTimeoutMs)
+      timer.unref?.()
+      guest.on('did-start-navigation', onNavigation)
+      cleanup = () => {
+        clearTimeout(timer)
+        guest.removeListener('did-start-navigation', onNavigation)
+      }
+    })
+    const guarded = call.finally(() => cleanup())
+    // Whichever promise loses the race must not surface as an unhandled rejection.
+    void guarded.catch(() => undefined)
+    void interrupted.catch(() => undefined)
+    return Promise.race([guarded, interrupted])
+  }
+
+  private async runPageScript(guest: WebContents, script: string, label: string): Promise<Record<string, unknown>> {
+    return parseScriptJson(await this.guardGuestCall(guest, guest.executeJavaScript(script)), label)
+  }
+
+  /**
+   * Keeps the per-tab queue alive. Every guest call is already bounded, so a
+   * still-pending action here is pathologically stuck; releasing the tail keeps
+   * later actions for the tab runnable instead of silently queueing behind a
+   * promise that will never settle.
+   */
+  private releaseQueueEventually(run: Promise<unknown>): Promise<unknown> {
+    return new Promise((resolveTail) => {
+      const timer = setTimeout(() => resolveTail(undefined), this.actionTimeoutMs + QUEUE_RELEASE_GRACE_MS)
+      timer.unref?.()
+      void run.catch(() => undefined).then(() => {
+        clearTimeout(timer)
+        resolveTail(undefined)
+      })
+    })
   }
 
   private emitActivity(tab: TabState): void {
@@ -786,7 +868,7 @@ export class AgentBrowserService {
   }
 
   private async pageInfo(guest: WebContents): Promise<PageInfo> {
-    const payload = parseScriptJson(await guest.executeJavaScript(pageInfoScript()), 'page info')
+    const payload = await this.runPageScript(guest, pageInfoScript(), 'page info')
     return {
       url: typeof payload.url === 'string' ? payload.url : guest.getURL(),
       title: typeof payload.title === 'string' ? payload.title : '',
@@ -813,7 +895,7 @@ export class AgentBrowserService {
 
   private async elementAt(guest: WebContents, point: { x: number; y: number }): Promise<Record<string, unknown> | null> {
     try {
-      const payload = parseScriptJson(await guest.executeJavaScript(elementAtPointScript(point.x, point.y)), 'element at point')
+      const payload = await this.runPageScript(guest, elementAtPointScript(point.x, point.y), 'element at point')
       return typeof payload.tag === 'string' ? { tag: payload.tag, name: typeof payload.name === 'string' ? payload.name : '' } : null
     } catch { return null }
   }
@@ -821,7 +903,7 @@ export class AgentBrowserService {
   private async resolvePoint(guest: WebContents, params: Record<string, unknown>, focus: boolean): Promise<{ x: number; y: number }> {
     if (params.ref !== undefined) {
       if (!Number.isSafeInteger(params.ref) || (params.ref as number) < 0 || (params.ref as number) > 999) throw new TypeError('ref must be an element number from browser_read_page')
-      const payload = parseScriptJson(await guest.executeJavaScript(refPointScript(params.ref as number, focus)), 'element ref')
+      const payload = await this.runPageScript(guest, refPointScript(params.ref as number, focus), 'element ref')
       if (typeof payload.error === 'string') throw new Error(payload.error.slice(0, 300))
       if (!Number.isSafeInteger(payload.x) || !Number.isSafeInteger(payload.y)) throw new Error('The element position could not be determined')
       return { x: payload.x as number, y: payload.y as number }

--- a/electron/main/browser/agent-service.ts
+++ b/electron/main/browser/agent-service.ts
@@ -1,4 +1,4 @@
-import type { WebContents } from 'electron'
+import type { Event, WebContents, WebContentsDidStartNavigationEventParams } from 'electron'
 import { randomBytes } from 'node:crypto'
 import type { AgentBrowserActivityEvent, AgentBrowserPointerEvent, AgentBrowserState, AgentBrowserTabRecord } from '../../../src/types/api'
 import { canonicalSessionPath } from '../session-paths'
@@ -703,9 +703,10 @@ export class AgentBrowserService {
         cleanup()
         reject(new Error(message))
       }
-      const onNavigation = (details: { isSameDocument?: boolean; isMainFrame?: boolean }) => {
-        if (details?.isSameDocument) return
-        if (details?.isMainFrame === false) return
+      const onNavigation = (details: Event<WebContentsDidStartNavigationEventParams>) => {
+        // Same-document navigations (pushState/replaceState, fragment) and
+        // subframe navigations leave the main-frame context intact.
+        if (details.isSameDocument || !details.isMainFrame) return
         fail(NAVIGATION_ABORTED_MESSAGE)
       }
       // Guest destruction is deliberately not an interrupt: Electron settles the

--- a/tests/backend/agent-browser-service.test.ts
+++ b/tests/backend/agent-browser-service.test.ts
@@ -494,4 +494,70 @@ describe('AgentBrowserService', () => {
     await expect(service.click('/sessions/a.jsonl', {})).rejects.toThrow(/ref .*or x and y/)
     await expect(service.click('/sessions/a.jsonl', { x: -5, y: 10 })).rejects.toThrow(/within the page viewport/)
   })
+
+  it('rejects an in-flight page script when the document is replaced', async () => {
+    const { service, openAttached } = fixture()
+    const { guest, tabId } = await openAttached('/sessions/a.jsonl', 'https://example.com/')
+    const started = deferred<void>()
+    // Chromium discards the execution context that owns the promise, so the
+    // script never settles; a never-resolving promise models exactly that.
+    guest.scriptResult = (code) => {
+      if (code.includes('navigates-away')) {
+        started.resolve()
+        return new Promise<string>(() => {})
+      }
+      return JSON.stringify({ executed: true })
+    }
+
+    const stranded = service.evaluate('/sessions/a.jsonl', { tabId, code: "'navigates-away'" })
+    await started.promise
+    guest.emit('did-start-navigation', { url: 'https://example.org/', isSameDocument: false, isMainFrame: true })
+
+    await expect(stranded).rejects.toThrow(/page navigated while this action was running/i)
+  })
+
+  it('keeps the tab usable after a navigation strands a page script', async () => {
+    const { service, openAttached } = fixture()
+    const { guest, tabId } = await openAttached('/sessions/a.jsonl', 'https://example.com/')
+    const started = deferred<void>()
+    guest.scriptResult = (code) => {
+      if (code.includes('navigates-away')) {
+        started.resolve()
+        return new Promise<string>(() => {})
+      }
+      return JSON.stringify({ recovered: true })
+    }
+
+    const stranded = service.evaluate('/sessions/a.jsonl', { tabId, code: "'navigates-away'" })
+    await started.promise
+    guest.emit('did-start-navigation', { url: 'https://example.org/', isSameDocument: false, isMainFrame: true })
+    await expect(stranded).rejects.toThrow(/page navigated while this action was running/i)
+
+    // Before the fix the per-tab queue stayed chained to the stranded promise,
+    // so every later action on this tab hung instead of running.
+    await expect(service.evaluate('/sessions/a.jsonl', { tabId, code: "'after-navigation'" })).resolves.toEqual({ recovered: true })
+  })
+
+  it('ignores same-document navigations while a page script runs', async () => {
+    const { service, openAttached } = fixture()
+    const { guest, tabId } = await openAttached('/sessions/a.jsonl', 'https://example.com/')
+    const started = deferred<void>()
+    const release = deferred<string>()
+    guest.scriptResult = (code) => {
+      if (code.includes('same-document')) {
+        started.resolve()
+        return release.promise
+      }
+      return JSON.stringify({ executed: true })
+    }
+
+    const running = service.evaluate('/sessions/a.jsonl', { tabId, code: "'same-document'" })
+    await started.promise
+    // pushState and hash changes keep the execution context alive.
+    guest.emit('did-start-navigation', { url: 'https://example.com/#section', isSameDocument: true, isMainFrame: true })
+    guest.emit('did-start-navigation', { url: 'https://example.com/frame', isSameDocument: false, isMainFrame: false })
+    release.resolve(JSON.stringify({ completed: true }))
+
+    await expect(running).resolves.toEqual({ completed: true })
+  })
 })

--- a/tests/backend/agent-browser-service.test.ts
+++ b/tests/backend/agent-browser-service.test.ts
@@ -65,6 +65,15 @@ class FakeGuest extends EventEmitter {
   }
   async insertText(value: string) { this.insertedText.push(value) }
   sendInputEvent() { throw new Error('sendInputEvent does not reach webview guests; use the debugger') }
+  /**
+   * Mirrors Electron's real `did-start-navigation` emit: a details object
+   * carrying `isSameDocument`/`isMainFrame` first, then the deprecated
+   * positional arguments that still trail it.
+   */
+  startNavigation({ url, isSameDocument, isMainFrame }: { url: string; isSameDocument: boolean; isMainFrame: boolean }) {
+    const details = { preventDefault: () => {}, defaultPrevented: false, url, isSameDocument, isMainFrame, frame: null }
+    this.emit('did-start-navigation', details, url, isSameDocument, isMainFrame, 1, 2)
+  }
   async executeJavaScript(code: string) {
     this.executedScripts.push(code)
     return this.scriptResult(code)
@@ -511,7 +520,7 @@ describe('AgentBrowserService', () => {
 
     const stranded = service.evaluate('/sessions/a.jsonl', { tabId, code: "'navigates-away'" })
     await started.promise
-    guest.emit('did-start-navigation', { url: 'https://example.org/', isSameDocument: false, isMainFrame: true })
+    guest.startNavigation({ url: 'https://example.org/', isSameDocument: false, isMainFrame: true })
 
     await expect(stranded).rejects.toThrow(/page navigated while this action was running/i)
   })
@@ -530,7 +539,7 @@ describe('AgentBrowserService', () => {
 
     const stranded = service.evaluate('/sessions/a.jsonl', { tabId, code: "'navigates-away'" })
     await started.promise
-    guest.emit('did-start-navigation', { url: 'https://example.org/', isSameDocument: false, isMainFrame: true })
+    guest.startNavigation({ url: 'https://example.org/', isSameDocument: false, isMainFrame: true })
     await expect(stranded).rejects.toThrow(/page navigated while this action was running/i)
 
     // Before the fix the per-tab queue stayed chained to the stranded promise,
@@ -554,8 +563,8 @@ describe('AgentBrowserService', () => {
     const running = service.evaluate('/sessions/a.jsonl', { tabId, code: "'same-document'" })
     await started.promise
     // pushState and hash changes keep the execution context alive.
-    guest.emit('did-start-navigation', { url: 'https://example.com/#section', isSameDocument: true, isMainFrame: true })
-    guest.emit('did-start-navigation', { url: 'https://example.com/frame', isSameDocument: false, isMainFrame: false })
+    guest.startNavigation({ url: 'https://example.com/#section', isSameDocument: true, isMainFrame: true })
+    guest.startNavigation({ url: 'https://example.com/frame', isSameDocument: false, isMainFrame: false })
     release.resolve(JSON.stringify({ completed: true }))
 
     await expect(running).resolves.toEqual({ completed: true })


### PR DESCRIPTION
Fixes #193

## Summary

- bound every guest call (`executeJavaScript`, `capturePage`) with `guardGuestCall`, which rejects on a context-replacing main-frame navigation and on an absolute deadline
- release the per-tab queue tail once the bounded action settles, or after the deadline plus a grace margin, so one stuck action can no longer hold a tab hostage
- route `evaluate`, `readPage`, `scroll`, `pageInfo`, `elementAt`, `resolvePoint`, and the screenshot cursor/capture path through the guard

## Root cause

`AgentBrowserService.evaluate` awaited `guest.executeJavaScript(...)` with no deadline. When a navigation replaces the document, Chromium discards the execution context that owns that promise, so it never resolves and never rejects.

`withTab` chains each action onto `tab.serial.tail`:

```ts
const run = tab.serial.tail.then(async () => { ... })
tab.serial.tail = run.catch(() => undefined)
```

A never-settling `run` means a never-settling `tail`, so every subsequent action for that tab queued behind it forever. The extension's `fetch` wrapper then reported the main-process deadlock as `OMP Work is not reachable: TimeoutError`, and only opening a brand-new tab (fresh `tail`) restored control.

## Design

`guardGuestCall` races the real call against an interrupt promise:

- `did-start-navigation` with `isSameDocument === false` on the main frame rejects with an actionable message pointing at `browser_navigate`
- same-document navigations (`pushState`, hash changes) and subframe navigations are ignored, since they leave the execution context intact
- an absolute `ACTION_TIMEOUT_MS` (30s, overridable via `actionTimeoutMs`) catches anything else that strands a call
- listeners and the timer are removed as soon as either side settles, and both race participants get a no-op `catch` so the loser cannot surface as an unhandled rejection

Guest destruction is deliberately **not** an interrupt. Electron settles the pending call itself on teardown, and PR #35 established that already-running work is never retroactively cancelled; adding a `destroyed` interrupt broke that contract in `rejects work queued for a destroyed guest while fresh work follows reattachment`.

`releaseQueueEventually` replaces `run.catch(() => undefined)` as the tail. Since every guest call is already bounded, a still-pending action at `ACTION_TIMEOUT_MS + QUEUE_RELEASE_GRACE_MS` is pathologically stuck, and liveness for the tab matters more than continued serialization.

## Impact

A navigation triggered from inside `browser_evaluate` now fails fast with a message telling the caller to navigate via `browser_navigate` first, and the tab stays usable. No change to the happy path, to serialization ordering, or to the authority model from #35.

## Checks

- `npx vitest run tests/backend/agent-browser-service.test.ts -t "navigat"` → 4 passed (the 3 new regressions plus the existing navigation test). The two wedge regressions fail without the production change: `stranded` hangs and the follow-up evaluate never resolves.
- `npx vitest run tests/backend/agent-browser-bridge.test.ts tests/backend/omp-browser-extension.test.ts` → 16 passed
- `npx tsc --noEmit -p tsconfig.node.json` and `-p tsconfig.tests.json` → clean
- `npx biome lint --config-path=scripts/release/biome.json electron/main/browser tests/backend/agent-browser-service.test.ts` → clean

`tests/backend/agent-browser-service.test.ts` reports 7 pre-existing failures on this machine that reproduce identically on a clean `main` checkout before my changes (preview/session-teardown timing on Windows); the count is unchanged by this PR, and the previously failing set is byte-identical.

`npm install` cannot complete here because `node-pty` fails `node-gyp` rebuild on this Windows box, so `npm run typecheck` and `npm test` were exercised via the installed `tsc`/`vitest` binaries directly rather than the full lifecycle scripts. CI should be the authority on the complete suite.
