### PR TITLE
chore: release GooeyPi 1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gooeypi",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gooeypi",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gooeypi",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "private": true,
   "description": "A desktop workspace for Pi, OMP, and Prime Agent",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary\n- bump GooeyPi package version to 1.1.16\n- keep package-lock.json aligned for release tag validation\n\nRelease tag: v1.1.16