### PR TITLE
Pass HOME through to git so global gitignore is respected

### DIFF
--- a/electron/main/process-utils.ts
+++ b/electron/main/process-utils.ts
@@ -330,7 +330,10 @@ function versionManagerRuntimeDirs(
 export function restrictedGitEnvironment(): NodeJS.ProcessEnv {
   // Git is invoked for repository-derived work, so inherit only process-location
   // values rather than credentials, provider tokens, signing agents, or Git's
-  // many environment-based configuration injection mechanisms.
+  // many environment-based configuration injection mechanisms. HOME/XDG_CONFIG_HOME
+  // are included so Git can still find the user's global excludes file
+  // (~/.config/git/ignore) — GIT_CONFIG_GLOBAL=/dev/null above already keeps it
+  // from reading ~/.gitconfig itself.
   const env: NodeJS.ProcessEnv = {
     LANG: 'C',
     LC_ALL: 'C',
@@ -346,8 +349,8 @@ export function restrictedGitEnvironment(): NodeJS.ProcessEnv {
     GIT_OPTIONAL_LOCKS: '0',
   }
   for (const key of process.platform === 'win32'
-    ? ['PATH', 'Path', 'SystemRoot', 'WINDIR', 'ComSpec', 'PATHEXT', 'TEMP', 'TMP']
-    : ['PATH', 'TMPDIR']) {
+    ? ['PATH', 'Path', 'SystemRoot', 'WINDIR', 'ComSpec', 'PATHEXT', 'TEMP', 'TMP', 'USERPROFILE', 'HOME']
+    : ['PATH', 'TMPDIR', 'HOME', 'XDG_CONFIG_HOME']) {
     const value = process.env[key]
     if (value !== undefined) env[key] = value
   }

--- a/tests/backend/git.test.ts
+++ b/tests/backend/git.test.ts
@@ -175,6 +175,26 @@ describe('GitService', () => {
     expect(changes.find((file) => file.staged)?.additions).toBe(1)
     expect(changes.find((file) => !file.staged)?.additions).toBe(1)
   })
+  it('respects the user global excludes file (~/.config/git/ignore) for untracked files', async () => {
+    const cwd = repository('prime-work-git-global-excludes-')
+    const home = mkdtempSync(join(tmpdir(), 'prime-work-git-home-'))
+    dirs.push(home)
+    mkdirSync(join(home, '.config', 'git'), { recursive: true })
+    writeFileSync(join(home, '.config', 'git', 'ignore'), '.idea/\n')
+    mkdirSync(join(cwd, '.idea'))
+    writeFileSync(join(cwd, '.idea', 'misc.xml'), '<misc/>\n')
+    const oldHome = process.env.HOME
+    process.env.HOME = home
+    try {
+      const service = new GitService(async () => cwd)
+      const status = await service.status(cwd)
+      expect(status.files.find((file) => file.path === '.idea/misc.xml')).toBeUndefined()
+    } finally {
+      if (oldHome === undefined) delete process.env.HOME
+      else process.env.HOME = oldHome
+    }
+  })
+
   it('restores staged, unstaged, and untracked changes to a clean worktree', async () => {
     const cwd = repository('prime-work-git-restore-all-')
     const service = new GitService(async () => cwd)


### PR DESCRIPTION
Fixes #206.

I found the cause: `restrictedGitEnvironment()` in `electron/main/process-utils.ts`
build a clean env for every git call (good, it strip credentials, signing
agent, config injection vars). But it does not pass `HOME` (or
`XDG_CONFIG_HOME`) through. Git need `HOME` to find the user's default
global excludes file (`~/.config/git/ignore` on Linux/XDG setup, same idea
elsewhere), so without it, files that plain `git status` correctly hide
still show up as untracked (`??`) inside GooeyPi's Changes view - exactly
what the issue describe.

I test this local, outside the app, same env shape as `restrictedGitEnvironment()`:

```
$ env -i GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 PATH="$PATH" git status --porcelain=v1 --untracked-files=all
?? .idea/misc.xml          # HOME missing - ignored file still show up

$ env -i HOME=$FAKE_HOME GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 PATH="$PATH" git status --porcelain=v1 --untracked-files=all
                            # HOME set - respects ~/.config/git/ignore, same as real git status
```

What change:
- Add `HOME`/`XDG_CONFIG_HOME` to the posix pass-through list, and
  `HOME`/`USERPROFILE` on Windows (git for Windows use either).
- This does **not** touch `GIT_CONFIG_GLOBAL=/dev/null` - `~/.gitconfig`
  itself still never get read, so a custom `core.excludesFile` path set
  there stay out of scope, same as before. Only the default XDG excludes
  lookup start working, which is what the issue is about.
- Added a regression test in `tests/backend/git.test.ts`, using the same
  swap-`process.env.HOME`-in-a-try/finally pattern already used by the
  "reads a safe user identity" test right above it.

`npx vitest run tests/backend/git.test.ts tests/backend/process-utils.test.ts`
- 52/52 pass. `npx biome lint --config-path=scripts/release/biome.json` on
  the 2 changed files - clean. `tsc --noEmit` on the node project - clean.

(Full `npx vitest run` has 5 pre-existing failures on my machine, all
unrelated to this change: 4 need Node >=24.15.0 and my sandbox has
24.10.0, 1 is a timing-sensitive test in `sessions.test.ts` that is not
touched here.)